### PR TITLE
fix: correct Spizza and Harry's coordinates in Love Dining

### DIFF
--- a/data/love-dining.json
+++ b/data/love-dining.json
@@ -358,7 +358,9 @@
     "notes": "For full list of contact details, please click here. Please note that Love Dining Privileges are applicable at all Harry's outlets except Changi Airport.",
     "source": "Amex Love Dining",
     "source_url": "https://www.americanexpress.com/sg/benefits/love-dining/love-restaurants.html",
-    "summary_ai": "Harry's is a popular bar and restaurant, known for its wide range of food and drink options, set in a lively atmosphere within a Singapore hotel. Its extensive menu and happy hour deals make it a great spot to meet friends."
+    "summary_ai": "Harry's is a popular bar and restaurant, known for its wide range of food and drink options, set in a lively atmosphere within a Singapore hotel. Its extensive menu and happy hour deals make it a great spot to meet friends.",
+    "lat": 1.285993,
+    "lon": 103.8499679
   },
   {
     "id": "love-l-ang-lus",
@@ -456,7 +458,7 @@
     "type": "restaurant",
     "cuisine_category": "Western",
     "cuisine": "",
-    "address": "271 Bukit Timah Road Balmoral Plaza #01-09 269 Jalan Kayu, Singapore 799497",
+    "address": "271 Bukit Timah Road Balmoral Plaza #01-09, Singapore 259708",
     "city": "Singapore",
     "country": "Singapore",
     "phone": "+65 6333 8148 / +65 6481 2453",
@@ -464,8 +466,8 @@
     "notes": "Spizza – Bukit Timah Spizza – Jalan Kayu",
     "source": "Amex Love Dining",
     "source_url": "https://www.americanexpress.com/sg/benefits/love-dining/love-restaurants.html",
-    "lat": 1.397132,
-    "lon": 103.8728895,
+    "lat": 1.3163433,
+    "lon": 103.8355655,
     "summary_ai": "Spizza draws on Italian cuisine, offering a range of delicious pizzas and pastas. The restaurant's relaxed setting is great for casual dining."
   },
   {


### PR DESCRIPTION
Spizza was geocoded to Jalan Kayu (1.397°N, north SG) due to a garbled address. Correct location is Balmoral Plaza, 271 Bukit Timah Rd. Harry's has no fixed location — set Boat Quay coords as reference.