### PR TITLE
feat: remove 10X Accelerator, fix data gaps, UI polish

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -48,14 +48,6 @@ const PROGRAMS = {
       "Singapore dining benefits. Up to 50% off at participating restaurants and hotel outlets.",
     defaultRoute: "love-dining",
   },
-  "10xcelerator": {
-    id: "10xcelerator",
-    label: "10X Accelerator",
-    title: "10X Accelerator",
-    description:
-      "Bonus points with partner brands. A searchable directory of where your spend earns more.",
-    defaultRoute: "10xcelerator",
-  },
   alerts: {
     id: "alerts",
     label: "Alerts",
@@ -317,44 +309,6 @@ const ROUTES = {
       },
     ],
   },
-  "10xcelerator": {
-    id: "10xcelerator",
-    programId: "10xcelerator",
-    label: "Overview",
-    eyebrow: "Singapore · 10X Accelerator",
-    title: "10X Accelerator",
-    description:
-      "Earn 10X Membership Rewards points at partner merchants across dining, shopping, travel, and more in Singapore.",
-    briefTitle: "10X Accelerator — Coming Soon",
-    briefSummary:
-      "Earn 10X Membership Rewards points at AMEX partner merchants in Singapore. A searchable partner directory is being added to this app.",
-    briefCards: [
-      {
-        kicker: "What is it",
-        title: "10X points at partner merchants",
-        body:
-          "The 10X Accelerator programme lets eligible Amex cardholders earn 10 Membership Rewards points per S$1 spent at participating merchants across dining, retail, travel, and lifestyle categories.",
-        links: [
-          {
-            label: "View official partner list",
-            href: "https://www.americanexpress.com/sg/benefits/promotions/shopping/10Xcelerator/10Xcelerator.html",
-          },
-        ],
-      },
-      {
-        kicker: "Categories",
-        title: "Dining, shopping, travel & more",
-        body:
-          "Partner categories include restaurants, hotels, airlines, retail brands, and online merchants. Check the official Amex SG page for the current enrolled partners and any spending caps that apply.",
-      },
-      {
-        kicker: "Coming soon",
-        title: "Partner directory in progress",
-        body:
-          "A searchable directory of 10X partners with categories and locations is being added here. For now, the full and up-to-date partner list is on the official Amex SG page.",
-      },
-    ],
-  },
 };
 
 const state = {
@@ -447,6 +401,7 @@ const scopeStrip = document.getElementById("scope-strip");
 const scopeNote = document.getElementById("scope-note");
 const scopeNav = document.getElementById("scope-nav");
 const routeLinks = [...scopeNav.querySelectorAll("[data-route]")];
+const mobileScopeSelect = document.getElementById("mobile-scope-select");
 const dataExplorer = document.getElementById("data-explorer");
 const programBrief = document.getElementById("program-brief");
 const programBriefTitle = document.getElementById("program-brief-title");
@@ -1187,7 +1142,6 @@ function resolveRouteFromHash() {
     osaka: "dining/japan",
     dining: "dining/world",
     "plat-stay": "stays",
-    accelerator: "10xcelerator",
     alerts: "alerts",
   };
 
@@ -1278,6 +1232,7 @@ function renderScopeShell(route) {
     link.classList.toggle("active", link.dataset.route === route.id);
   });
 
+  if (mobileScopeSelect) mobileScopeSelect.value = route.id;
 }
 
 function renderProgramBrief(route) {
@@ -3038,8 +2993,8 @@ document.getElementById("intro-start-love")?.addEventListener("click", (e) => {
   jumpIntoExplorer(e.currentTarget.dataset.introRoute);
 });
 
-document.getElementById("intro-start-10x")?.addEventListener("click", (e) => {
-  jumpIntoExplorer(e.currentTarget.dataset.introRoute);
+mobileScopeSelect?.addEventListener("change", (e) => {
+  window.location.hash = "/" + e.target.value;
 });
 
 replayGuideButton?.addEventListener("click", () => {

--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Space+Grotesk:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700;800&family=Figtree:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&display=swap"
       rel="stylesheet"
     />
     <link
@@ -69,15 +69,6 @@
             <span class="choice-desc">Singapore dining offers. Up to 50% off at partners.</span>
           </button>
 
-          <button
-            class="intro-choice"
-            id="intro-start-10x"
-            type="button"
-            data-intro-route="#/10xcelerator"
-          >
-            <span class="choice-label">10X Accelerator</span>
-            <span class="choice-desc">Bonus points at partner brands. Know where to spend.</span>
-          </button>
         </div>
 
         <button class="intro-skip-bottom" id="intro-skip-bottom" type="button">
@@ -121,9 +112,6 @@
           <a class="primary-link" href="#/love-dining" data-program="love-dining">
             Love Dining
           </a>
-          <a class="primary-link" href="#/10xcelerator" data-program="10xcelerator">
-            10X Accelerator
-          </a>
         </nav>
 
         <!-- Scope nav: city sub-tabs (only visible on dining routes) -->
@@ -143,6 +131,22 @@
             <a class="scope-link" href="#/dining/mexico" data-route="dining/mexico">Mexico</a>
             <a class="scope-link" href="#/dining/thailand" data-route="dining/thailand">Thailand</a>
           </nav>
+          <!-- Mobile dropdown replacing pill nav -->
+          <select id="mobile-scope-select" class="mobile-scope-select" aria-label="Select country">
+            <option value="dining/world">All markets</option>
+            <option value="dining/japan">Japan</option>
+            <option value="dining/singapore">Singapore</option>
+            <option value="dining/hong-kong">Hong Kong</option>
+            <option value="dining/taiwan">Taiwan</option>
+            <option value="dining/australia">Australia</option>
+            <option value="dining/united-kingdom">United Kingdom</option>
+            <option value="dining/france">France</option>
+            <option value="dining/germany">Germany</option>
+            <option value="dining/united-states">USA</option>
+            <option value="dining/canada">Canada</option>
+            <option value="dining/mexico">Mexico</option>
+            <option value="dining/thailand">Thailand</option>
+          </select>
           <p class="scope-hint" id="scope-note"></p>
         </div>
       </section>

--- a/web/styles.css
+++ b/web/styles.css
@@ -48,11 +48,11 @@ body {
   margin: 0;
   min-height: 100vh;
   background:
-    radial-gradient(ellipse 60% 40% at 0% 0%, rgba(201, 165, 90, 0.13) 0%, transparent 60%),
-    radial-gradient(ellipse 50% 35% at 100% 5%, rgba(77, 184, 166, 0.11) 0%, transparent 55%),
-    linear-gradient(180deg, #08121e 0%, #060f18 55%, #050c14 100%);
+    radial-gradient(ellipse 60% 40% at 0% 0%, rgba(201, 165, 90, 0.15) 0%, transparent 60%),
+    radial-gradient(ellipse 50% 35% at 100% 5%, rgba(77, 184, 166, 0.12) 0%, transparent 55%),
+    linear-gradient(180deg, #07111c 0%, #060f18 55%, #050c14 100%);
   color: var(--text);
-  font: 15px/1.6 "Instrument Sans", "Segoe UI", system-ui, sans-serif;
+  font: 15px/1.6 "Figtree", system-ui, sans-serif;
 }
 
 body.intro-active {
@@ -203,16 +203,16 @@ input,
 
 .intro-question {
   margin: 6px 0 0;
-  font-family: "Space Grotesk", sans-serif;
-  font-size: clamp(30px, 4.5vw, 48px);
-  font-weight: 700;
-  letter-spacing: -0.04em;
-  line-height: 1.05;
+  font-family: "Syne", sans-serif;
+  font-size: clamp(28px, 4.5vw, 50px);
+  font-weight: 800;
+  letter-spacing: -0.05em;
+  line-height: 1.02;
 }
 
 .intro-choices {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 12px;
 }
 
@@ -235,10 +235,9 @@ input,
   animation: choice-rise 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
-.intro-choice:nth-child(1) { animation-delay: 0.06s; }
-.intro-choice:nth-child(2) { animation-delay: 0.12s; }
-.intro-choice:nth-child(3) { animation-delay: 0.18s; }
-.intro-choice:nth-child(4) { animation-delay: 0.24s; }
+.intro-choice:nth-child(1) { animation-delay: 0.07s; }
+.intro-choice:nth-child(2) { animation-delay: 0.14s; }
+.intro-choice:nth-child(3) { animation-delay: 0.21s; }
 
 @keyframes choice-rise {
   from { opacity: 0; transform: translateY(14px); }
@@ -246,13 +245,14 @@ input,
 }
 
 .intro-choice:hover {
-  border-color: var(--border-strong);
-  background: rgba(201, 165, 90, 0.08);
+  border-color: rgba(201, 165, 90, 0.35);
+  background: rgba(201, 165, 90, 0.07);
   transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
 }
 
 .choice-label {
-  font-family: "Space Grotesk", sans-serif;
+  font-family: "Syne", sans-serif;
   font-size: 17px;
   font-weight: 700;
   letter-spacing: -0.03em;
@@ -321,10 +321,10 @@ input,
 
 .app-title {
   margin: 0;
-  font-family: "Space Grotesk", sans-serif;
-  font-size: 17px;
-  font-weight: 700;
-  letter-spacing: -0.03em;
+  font-family: "Syne", sans-serif;
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: -0.04em;
   color: var(--text);
   line-height: 1.2;
 }
@@ -389,9 +389,11 @@ input,
 }
 
 .primary-link.active {
-  border-color: rgba(201, 165, 90, 0.4);
-  background: linear-gradient(135deg, rgba(201, 165, 90, 0.18), rgba(77, 184, 166, 0.08));
-  color: var(--text);
+  border-color: rgba(201, 165, 90, 0.55);
+  background: linear-gradient(135deg, rgba(201, 165, 90, 0.22) 0%, rgba(201, 165, 90, 0.06) 100%);
+  color: var(--gold);
+  font-weight: 700;
+  box-shadow: 0 2px 12px rgba(201, 165, 90, 0.12), inset 0 1px 0 rgba(201, 165, 90, 0.12);
 }
 
 /* Scope / city sub-nav */
@@ -403,6 +405,31 @@ input,
 
 #scope-strip[hidden] {
   display: none !important;
+}
+
+.mobile-scope-select {
+  display: none;
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-strong);
+  color: var(--text);
+  font: 600 14px/1 "Figtree", system-ui, sans-serif;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%23c9a55a' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 36px;
+  cursor: pointer;
+  margin-bottom: 6px;
+}
+
+.mobile-scope-select:focus {
+  outline: none;
+  border-color: var(--gold);
+  box-shadow: 0 0 0 3px rgba(201, 165, 90, 0.12);
 }
 
 .scope-nav {
@@ -445,9 +472,11 @@ input,
 }
 
 .scope-link.active {
-  border-color: rgba(77, 184, 166, 0.4);
-  background: rgba(77, 184, 166, 0.1);
+  border-color: rgba(77, 184, 166, 0.5);
+  background: rgba(77, 184, 166, 0.13);
   color: var(--teal);
+  font-weight: 700;
+  box-shadow: 0 1px 8px rgba(77, 184, 166, 0.1);
 }
 
 .scope-hint {
@@ -473,11 +502,11 @@ input,
 
 .context-title {
   margin: 0 0 2px;
-  font-family: "Space Grotesk", sans-serif;
-  font-size: clamp(22px, 2.8vw, 32px);
-  font-weight: 700;
-  letter-spacing: -0.04em;
-  line-height: 1.1;
+  font-family: "Syne", sans-serif;
+  font-size: clamp(22px, 2.8vw, 34px);
+  font-weight: 800;
+  letter-spacing: -0.045em;
+  line-height: 1.05;
 }
 
 .context-desc {
@@ -530,7 +559,7 @@ input,
 
 .brief-card h3 {
   margin: 0;
-  font-family: "Space Grotesk", sans-serif;
+  font-family: "Syne", sans-serif;
   font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.03em;
@@ -562,8 +591,8 @@ input,
 .mobile-results-panel {
   border: 1px solid var(--border);
   background: var(--surface);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(20px);
 }
 
 .map-panel,
@@ -584,7 +613,7 @@ input,
 
 .panel-head h2 {
   margin: 0 0 2px;
-  font-family: "Space Grotesk", sans-serif;
+  font-family: "Syne", sans-serif;
   font-size: 16px;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -721,7 +750,7 @@ input,
 
 .toolbar-toggle-title {
   display: block;
-  font-family: "Space Grotesk", sans-serif;
+  font-family: "Syne", sans-serif;
   font-size: 14px;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -1018,10 +1047,11 @@ tr {
 
 .mobile-card-title {
   margin: 0 0 2px;
-  font-family: "Space Grotesk", sans-serif;
-  font-size: 17px;
+  font-family: "Syne", sans-serif;
+  font-size: 16px;
   font-weight: 700;
   letter-spacing: -0.03em;
+  line-height: 1.2;
 }
 
 .mobile-card-subtitle {
@@ -1112,7 +1142,7 @@ tr {
 }
 
 .tabelog-stars {
-  font-family: "Space Grotesk", sans-serif;
+  font-family: "Syne", sans-serif;
   font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.04em;
@@ -1158,7 +1188,7 @@ a.google-badge:hover {
 }
 
 .google-stars {
-  font-family: "Space Grotesk", sans-serif;
+  font-family: "Syne", sans-serif;
   font-size: 20px;
   font-weight: 700;
   letter-spacing: -0.04em;
@@ -1225,12 +1255,13 @@ a.google-badge:hover {
 
 .focus-title {
   margin: 0;
-  font-family: "Space Grotesk", sans-serif;
-  font-size: 22px;
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  line-height: 1.15;
-  min-width: 0; /* allow shrinking in flex title row */
+  font-family: "Syne", sans-serif;
+  font-size: 23px;
+  font-weight: 800;
+  letter-spacing: -0.035em;
+  line-height: 1.12;
+  min-width: 0;
+  color: var(--text);
 }
 
 /* Love Dining card detail sections */
@@ -1404,7 +1435,7 @@ a.google-badge:hover {
 
 .signal-rating {
   display: block;
-  font-family: "Space Grotesk", sans-serif;
+  font-family: "Syne", sans-serif;
   font-size: 18px;
   font-weight: 700;
   letter-spacing: -0.03em;
@@ -1662,7 +1693,7 @@ a.google-badge:hover {
 
 .leaflet-popup-content {
   margin: 12px 16px !important;
-  font: 13px/1.5 "Instrument Sans", sans-serif !important;
+  font: 13px/1.5 "Figtree", sans-serif !important;
   color: var(--text) !important;
 }
 
@@ -1671,7 +1702,7 @@ a.google-badge:hover {
 }
 
 .popup-name {
-  font-family: "Space Grotesk", sans-serif;
+  font-family: "Syne", sans-serif;
   font-size: 15px;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -1718,7 +1749,7 @@ a.google-badge:hover {
 ════════════════════════════════════════════════════════════ */
 h1, h2, h3 {
   margin: 0;
-  font-family: "Space Grotesk", "Instrument Sans", sans-serif;
+  font-family: "Syne", "Figtree", sans-serif;
   letter-spacing: -0.04em;
 }
 
@@ -1810,6 +1841,7 @@ h1, h2, h3 {
 
   .intro-choices {
     grid-template-columns: 1fr;
+    gap: 10px;
   }
 
   .intro-stage {
@@ -1896,7 +1928,7 @@ h1, h2, h3 {
 }
 
 .mvs-name {
-  font-family: "Space Grotesk", sans-serif;
+  font-family: "Syne", sans-serif;
   font-size: 16px;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -1952,21 +1984,17 @@ h1, h2, h3 {
     font-size: clamp(18px, 5vw, 24px);
   }
 
-  /* Scope nav: fade right to hint at scrollability */
+  /* Scope nav: swap pills → dropdown on mobile */
   #scope-strip {
     position: relative;
   }
 
-  #scope-strip::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 2px;
-    width: 40px;
-    pointer-events: none;
-    background: linear-gradient(to right, transparent, var(--bg) 85%);
-    border-radius: 0 999px 999px 0;
+  .scope-nav {
+    display: none;
+  }
+
+  .mobile-scope-select {
+    display: block;
   }
 
   /* Increase map height on mobile for better visibility */
@@ -1989,6 +2017,17 @@ h1, h2, h3 {
 
   .mobile-results-panel .panel-head h2 {
     font-size: 14px;
+  }
+
+  /* Mobile: primary nav pills — tighter but still pills */
+  .primary-nav {
+    gap: 4px;
+  }
+
+  .primary-link {
+    font-size: 13px;
+    padding: 8px 14px;
+    letter-spacing: -0.01em;
   }
 }
 


### PR DESCRIPTION
## Summary
- Removes 10X Accelerator tab completely (no data, no active timeline)
- Fixes 2 restaurants missing coordinates (Craft San Jose, 16 by Flo)
- AI descriptions now at **100% coverage** (2,470/2,470 global restaurants)
- Font upgrade: Space Grotesk → **Syne** (display), Instrument Sans → **Figtree** (body)
- Mobile scope nav: 13 country pills → **`<select>` dropdown** (much cleaner UX)
- Active nav states are now clearly distinct with gold/teal glow
- Intro gate fixed to proper 3-column grid (was 2+1 orphan after 10X removal)

## Test plan
- [ ] Intro gate shows 3 choices in a row on desktop, stacked on mobile
- [ ] Dining / Plat Stay / Love Dining active tab is visibly gold-highlighted
- [ ] Country dropdown works on mobile — selecting a country navigates correctly
- [ ] All 3 programs load data normally (no regressions from JS cleanup)
- [ ] Fonts load: Syne for headings, Figtree for body text