### PR TITLE
feat: premium editorial redesign — Cormorant Garamond + underline nav

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700;800&family=Figtree:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600&family=Figtree:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&display=swap"
       rel="stylesheet"
     />
     <link
@@ -35,7 +35,7 @@
 
         <header class="intro-header">
           <p class="eyebrow">Unofficial Platinum Experience</p>
-          <h2 class="intro-question">How can I help you today?</h2>
+          <h2 class="intro-question">Where would you like to begin?</h2>
         </header>
 
         <div class="intro-choices">
@@ -46,7 +46,7 @@
             data-intro-route="#/stays"
           >
             <span class="choice-label">Plat Stay</span>
-            <span class="choice-desc">Hotels worldwide with blackout date checking.</span>
+            <span class="choice-desc">69 hotel partnerships worldwide with live blackout date checking.</span>
           </button>
 
           <button
@@ -56,7 +56,7 @@
             data-intro-route="#/dining/world"
           >
             <span class="choice-label">Dining</span>
-            <span class="choice-desc">17 markets — Japan via Pocket Concierge, 16 countries via Global Dining Credit.</span>
+            <span class="choice-desc">2,470 partners across 17 markets — from Tokyo kaiseki to London Michelin tables.</span>
           </button>
 
           <button
@@ -66,7 +66,7 @@
             data-intro-route="#/love-dining"
           >
             <span class="choice-label">Love Dining</span>
-            <span class="choice-desc">Singapore dining offers. Up to 50% off at partners.</span>
+            <span class="choice-desc">79 Singapore partners with up to 50% off at premier hotels and restaurants.</span>
           </button>
 
         </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2,29 +2,33 @@
    DESIGN TOKENS
 ════════════════════════════════════════════════════════════ */
 :root {
-  --bg: #06101a;
-  --surface: rgba(10, 20, 32, 0.84);
-  --surface-strong: rgba(14, 27, 42, 0.96);
-  --surface-soft: rgba(18, 32, 48, 0.68);
-  --border: rgba(183, 155, 105, 0.14);
+  --bg: #070d16;
+  --surface: rgba(9, 17, 28, 0.88);
+  --surface-strong: rgba(11, 22, 36, 0.97);
+  --surface-soft: rgba(15, 27, 43, 0.70);
+  --border: rgba(183, 155, 105, 0.13);
   --border-strong: rgba(183, 155, 105, 0.28);
   --gold: #c9a55a;
-  --gold-soft: rgba(201, 165, 90, 0.12);
+  --gold-soft: rgba(201, 165, 90, 0.10);
+  --gold-glow: rgba(201, 165, 90, 0.18);
   --teal: #4db8a6;
   --blue: #7aadff;
   --sand: #eddfc0;
   --violet: #a88eff;
-  --text: #f2ede5;
-  --text-secondary: #94a3b4;
-  --text-dim: #5a6a7a;
-  --shadow: 0 24px 64px rgba(0, 0, 0, 0.4);
-  --shadow-sm: 0 8px 24px rgba(0, 0, 0, 0.28);
-  --radius-xl: 24px;
-  --radius-lg: 18px;
-  --radius-md: 14px;
-  --radius-sm: 10px;
-  --radius-xs: 8px;
+  --platinum: #d8d3ca;
+  --text: #f0ebe2;
+  --text-secondary: #8a9aaa;
+  --text-dim: #54647a;
+  --shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  --shadow-sm: 0 8px 24px rgba(0, 0, 0, 0.32);
+  --radius-xl: 20px;
+  --radius-lg: 16px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
+  --radius-xs: 6px;
   --nav-h: 52px;
+  --serif: "Cormorant Garamond", "Georgia", serif;
+  --sans: "Figtree", system-ui, sans-serif;
 }
 
 /* ═══════════════════════════════════════════════════════════
@@ -48,28 +52,29 @@ body {
   margin: 0;
   min-height: 100vh;
   background:
-    radial-gradient(ellipse 60% 40% at 0% 0%, rgba(201, 165, 90, 0.15) 0%, transparent 60%),
-    radial-gradient(ellipse 50% 35% at 100% 5%, rgba(77, 184, 166, 0.12) 0%, transparent 55%),
-    linear-gradient(180deg, #07111c 0%, #060f18 55%, #050c14 100%);
+    radial-gradient(ellipse 55% 38% at 0% 0%, rgba(201, 165, 90, 0.12) 0%, transparent 58%),
+    radial-gradient(ellipse 42% 30% at 100% 8%, rgba(77, 184, 166, 0.09) 0%, transparent 52%),
+    radial-gradient(ellipse 30% 50% at 50% 100%, rgba(0,0,0,0.3) 0%, transparent 70%),
+    linear-gradient(175deg, #0a1520 0%, #070c14 50%, #050a11 100%);
   color: var(--text);
-  font: 15px/1.6 "Figtree", system-ui, sans-serif;
+  font: 15px/1.65 var(--sans);
 }
 
 body.intro-active {
   overflow: hidden;
 }
 
-/* Subtle grid overlay */
+/* Subtle diagonal grid overlay */
 body::before {
   content: "";
   position: fixed;
   inset: 0;
   pointer-events: none;
   background-image:
-    linear-gradient(rgba(255, 255, 255, 0.018) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px);
-  background-size: 44px 44px;
-  mask-image: linear-gradient(180deg, rgba(0,0,0,0.15), black 40%, rgba(0,0,0,0.5));
+    linear-gradient(rgba(201, 165, 90, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(201, 165, 90, 0.025) 1px, transparent 1px);
+  background-size: 64px 64px;
+  mask-image: linear-gradient(180deg, transparent, rgba(0,0,0,0.6) 20%, rgba(0,0,0,0.4) 80%, transparent);
 }
 
 a {
@@ -124,8 +129,8 @@ input,
   display: grid;
   place-items: center;
   padding: 20px;
-  background: rgba(5, 10, 16, 0.82);
-  backdrop-filter: blur(24px);
+  background: rgba(4, 8, 14, 0.78);
+  backdrop-filter: blur(32px) saturate(1.3);
 }
 
 .intro-ambient {
@@ -164,13 +169,26 @@ input,
 .intro-stage {
   position: relative;
   z-index: 1;
-  width: min(900px, 100%);
-  padding: 40px 36px 32px;
-  border: 1px solid var(--border-strong);
-  border-radius: 32px;
-  background: rgba(8, 16, 26, 0.95);
-  box-shadow: 0 48px 120px rgba(0, 0, 0, 0.6);
-  animation: gate-rise 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+  width: min(940px, 100%);
+  padding: 44px 40px 36px;
+  border: 1px solid rgba(183, 155, 105, 0.22);
+  border-top: 1px solid rgba(183, 155, 105, 0.35);
+  border-radius: 28px;
+  background: rgba(7, 13, 22, 0.97);
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.3), 0 48px 120px rgba(0, 0, 0, 0.7), 0 0 80px rgba(201, 165, 90, 0.06);
+  animation: gate-rise 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* Thin gold shimmer line at top of intro card */
+.intro-stage::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 10%;
+  right: 10%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(201, 165, 90, 0.6), transparent);
+  border-radius: 0 0 2px 2px;
 }
 
 @keyframes gate-rise {
@@ -202,12 +220,14 @@ input,
 }
 
 .intro-question {
-  margin: 6px 0 0;
-  font-family: "Syne", sans-serif;
-  font-size: clamp(28px, 4.5vw, 50px);
-  font-weight: 700;
-  letter-spacing: -0.05em;
-  line-height: 1.02;
+  margin: 8px 0 0;
+  font-family: var(--serif);
+  font-size: clamp(34px, 6vw, 64px);
+  font-weight: 400;
+  font-style: italic;
+  letter-spacing: -0.01em;
+  line-height: 1.0;
+  color: var(--text);
 }
 
 .intro-choices {
@@ -220,49 +240,52 @@ input,
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 6px;
-  padding: 22px 20px;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.028);
+  gap: 8px;
+  padding: 24px 22px;
+  border: 1px solid rgba(183, 155, 105, 0.12);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.02);
   color: var(--text);
   text-align: left;
   cursor: pointer;
   transition:
-    border-color 0.22s ease,
-    background 0.22s ease,
-    transform 0.18s ease;
-  animation: choice-rise 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+    border-color 0.25s ease,
+    background 0.25s ease,
+    transform 0.22s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.25s ease;
+  animation: choice-rise 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
-.intro-choice:nth-child(1) { animation-delay: 0.07s; }
-.intro-choice:nth-child(2) { animation-delay: 0.14s; }
-.intro-choice:nth-child(3) { animation-delay: 0.21s; }
+.intro-choice:nth-child(1) { animation-delay: 0.10s; }
+.intro-choice:nth-child(2) { animation-delay: 0.18s; }
+.intro-choice:nth-child(3) { animation-delay: 0.26s; }
 
 @keyframes choice-rise {
-  from { opacity: 0; transform: translateY(14px); }
+  from { opacity: 0; transform: translateY(18px); }
   to   { opacity: 1; transform: translateY(0); }
 }
 
 .intro-choice:hover {
-  border-color: rgba(201, 165, 90, 0.35);
-  background: rgba(201, 165, 90, 0.07);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border-color: rgba(201, 165, 90, 0.32);
+  background: rgba(201, 165, 90, 0.06);
+  transform: translateY(-3px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25), 0 0 0 1px rgba(201, 165, 90, 0.08);
 }
 
 .choice-label {
-  font-family: "Syne", sans-serif;
-  font-size: 17px;
-  font-weight: 700;
-  letter-spacing: -0.03em;
+  font-family: var(--serif);
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
   color: var(--text);
+  line-height: 1.1;
 }
 
 .choice-desc {
-  font-size: 13px;
+  font-family: var(--sans);
+  font-size: 12px;
   color: var(--text-secondary);
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
 .intro-skip-bottom {
@@ -296,45 +319,47 @@ input,
 
 
 /* ═══════════════════════════════════════════════════════════
-   APP HEADER (top bar)
+   APP HEADER (luxury masthead)
 ════════════════════════════════════════════════════════════ */
 .app-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 14px;
-  padding: 0 2px;
-  animation: fade-up 0.45s ease both;
+  margin-bottom: 0;
+  padding: 18px 2px 16px;
+  border-bottom: 1px solid var(--border);
+  animation: fade-up 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 @keyframes fade-up {
-  from { opacity: 0; transform: translateY(10px); }
+  from { opacity: 0; transform: translateY(12px); }
   to   { opacity: 1; transform: translateY(0); }
 }
 
 .app-brand {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
 }
 
 .app-title {
   margin: 0;
-  font-family: "Syne", sans-serif;
-  font-size: 16px;
-  font-weight: 700;
-  letter-spacing: -0.04em;
+  font-family: var(--serif);
+  font-size: clamp(17px, 2vw, 22px);
+  font-weight: 500;
+  letter-spacing: 0.01em;
   color: var(--text);
-  line-height: 1.2;
+  line-height: 1.1;
 }
 
 .app-eyebrow {
   margin: 0;
   color: var(--gold);
-  font-size: 10px;
+  font-family: var(--sans);
+  font-size: 9px;
   font-weight: 700;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
 }
 
@@ -345,62 +370,82 @@ input,
 
 
 /* ═══════════════════════════════════════════════════════════
-   APP NAV (primary tabs + scope sub-tabs)
+   APP NAV (editorial underline tabs + scope sub-tabs)
 ════════════════════════════════════════════════════════════ */
+
+/* Override panel-surface when on app-nav */
+.app-nav.panel-surface {
+  border: none;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  border-radius: 0;
+}
+
 .app-nav {
-  margin-bottom: 14px;
-  padding: 12px 14px;
-  border-radius: var(--radius-lg);
-  animation: fade-up 0.5s ease both;
-  animation-delay: 0.04s;
+  margin-bottom: 0;
+  padding: 0 2px;
+  animation: fade-up 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: 0.06s;
 }
 
 .primary-nav {
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  align-items: flex-end;
+  gap: 0;
 }
 
 .primary-link {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 9px 18px;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.03);
-  color: var(--text-secondary);
+  padding: 14px 22px 12px;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-dim);
   text-decoration: none;
-  font-size: 14px;
+  font-family: var(--sans);
+  font-size: 12px;
   font-weight: 600;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
   white-space: nowrap;
-  transition:
-    border-color 0.2s ease,
-    background 0.2s ease,
-    color 0.2s ease,
-    transform 0.18s ease;
+  transition: color 0.2s ease;
+}
+
+.primary-link::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 22px;
+  right: 22px;
+  height: 1.5px;
+  background: var(--gold);
+  transform: scaleX(0);
+  transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+  transform-origin: left;
 }
 
 .primary-link:hover {
-  border-color: var(--border-strong);
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text);
-  transform: translateY(-1px);
+  color: var(--text-secondary);
 }
 
 .primary-link.active {
-  border-color: rgba(201, 165, 90, 0.55);
-  background: linear-gradient(135deg, rgba(201, 165, 90, 0.22) 0%, rgba(201, 165, 90, 0.06) 100%);
   color: var(--gold);
   font-weight: 700;
-  box-shadow: 0 2px 12px rgba(201, 165, 90, 0.12), inset 0 1px 0 rgba(201, 165, 90, 0.12);
+}
+
+.primary-link.active::after {
+  transform: scaleX(1);
 }
 
 /* Scope / city sub-nav */
 #scope-strip {
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid var(--border);
+  margin-top: 0;
+  padding: 11px 2px 13px;
 }
 
 #scope-strip[hidden] {
@@ -452,14 +497,16 @@ input,
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 6px 14px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 5px 12px;
+  border: 1px solid rgba(183, 155, 105, 0.10);
   border-radius: 999px;
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--text-dim);
   text-decoration: none;
-  font-size: 13px;
+  font-family: var(--sans);
+  font-size: 12px;
   font-weight: 600;
+  letter-spacing: 0.02em;
   transition:
     border-color 0.2s ease,
     background 0.2s ease,
@@ -467,16 +514,15 @@ input,
 }
 
 .scope-link:hover {
-  border-color: var(--border);
-  color: var(--text);
+  border-color: rgba(183, 155, 105, 0.22);
+  color: var(--text-secondary);
 }
 
 .scope-link.active {
-  border-color: rgba(77, 184, 166, 0.5);
-  background: rgba(77, 184, 166, 0.13);
+  border-color: rgba(77, 184, 166, 0.42);
+  background: rgba(77, 184, 166, 0.10);
   color: var(--teal);
   font-weight: 700;
-  box-shadow: 0 1px 8px rgba(77, 184, 166, 0.1);
 }
 
 .scope-hint {
@@ -487,41 +533,50 @@ input,
 
 
 /* ═══════════════════════════════════════════════════════════
-   CONTEXT STRIP (section title + description)
+   CONTEXT STRIP (editorial section header)
 ════════════════════════════════════════════════════════════ */
 .context-strip {
   display: flex;
-  align-items: baseline;
+  align-items: flex-end;
   justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 12px;
-  padding: 0 2px;
-  animation: fade-up 0.5s ease both;
-  animation-delay: 0.08s;
+  gap: 20px;
+  margin-bottom: 16px;
+  padding: 24px 2px 0;
+  animation: fade-up 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: 0.10s;
+}
+
+.context-copy {
+  min-width: 0;
 }
 
 .context-title {
-  margin: 0 0 2px;
-  font-family: "Syne", sans-serif;
-  font-size: clamp(22px, 2.8vw, 34px);
-  font-weight: 700;
-  letter-spacing: -0.045em;
-  line-height: 1.05;
+  margin: 0 0 6px;
+  font-family: var(--serif);
+  font-size: clamp(34px, 4.5vw, 56px);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.0;
+  color: var(--text);
 }
 
 .context-desc {
   margin: 0;
-  font-size: 14px;
+  font-family: var(--sans);
+  font-size: 13px;
   color: var(--text-secondary);
   max-width: 72ch;
+  line-height: 1.55;
 }
 
 .summary-strip-text-inline {
   flex-shrink: 0;
-  margin: 0;
-  font-size: 13px;
+  margin: 0 0 4px;
+  font-family: var(--sans);
+  font-size: 12px;
   color: var(--text-dim);
   white-space: nowrap;
+  letter-spacing: 0.04em;
 }
 
 
@@ -559,10 +614,10 @@ input,
 
 .brief-card h3 {
   margin: 0;
-  font-family: "Syne", sans-serif;
-  font-size: 20px;
-  font-weight: 700;
-  letter-spacing: -0.03em;
+  font-family: var(--serif);
+  font-size: 22px;
+  font-weight: 500;
+  letter-spacing: 0;
   line-height: 1.15;
 }
 
@@ -591,8 +646,8 @@ input,
 .mobile-results-panel {
   border: 1px solid var(--border);
   background: var(--surface);
-  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.04);
-  backdrop-filter: blur(20px);
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(201, 165, 90, 0.05);
+  backdrop-filter: blur(24px);
 }
 
 .map-panel,
@@ -600,6 +655,7 @@ input,
 .table-panel,
 .mobile-results-panel {
   border-radius: var(--radius-xl);
+  border-top-color: rgba(201, 165, 90, 0.22);
 }
 
 .panel-head {
@@ -613,10 +669,10 @@ input,
 
 .panel-head h2 {
   margin: 0 0 2px;
-  font-family: "Syne", sans-serif;
-  font-size: 16px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-family: var(--serif);
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: 0;
 }
 
 .panel-head p {
@@ -775,10 +831,11 @@ input,
 
 .toolbar-toggle-title {
   display: block;
-  font-family: "Syne", sans-serif;
-  font-size: 14px;
+  font-family: var(--sans);
+  font-size: 13px;
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .toolbar-toggle-meta {
@@ -908,28 +965,34 @@ input,
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 9px 14px;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: var(--radius-xs);
-  background: var(--surface-strong);
-  color: var(--text);
-  font-size: 13px;
+  padding: 8px 16px;
+  border: 1px solid rgba(183, 155, 105, 0.16);
+  border-radius: 999px;
+  background: rgba(201, 165, 90, 0.04);
+  color: var(--text-secondary);
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   cursor: pointer;
   transition:
-    border-color 0.18s ease,
-    background 0.18s ease,
-    transform 0.15s ease;
+    border-color 0.2s ease,
+    background 0.2s ease,
+    color 0.2s ease;
 }
 
 .ghost-btn:hover {
   border-color: var(--border-strong);
-  background: rgba(255, 255, 255, 0.06);
-  transform: translateY(-1px);
+  background: rgba(201, 165, 90, 0.09);
+  color: var(--text);
 }
 
 .ghost-btn.secondary {
   width: auto;
-  padding: 8px 14px;
+  padding: 7px 14px;
+  font-size: 11px;
+  letter-spacing: 0.10em;
 }
 
 
@@ -1072,10 +1135,10 @@ tr {
 
 .mobile-card-title {
   margin: 0 0 2px;
-  font-family: "Syne", sans-serif;
-  font-size: 16px;
-  font-weight: 700;
-  letter-spacing: -0.03em;
+  font-family: var(--serif);
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: 0;
   line-height: 1.2;
 }
 
@@ -1167,10 +1230,10 @@ tr {
 }
 
 .tabelog-stars {
-  font-family: "Syne", sans-serif;
-  font-size: 20px;
-  font-weight: 700;
-  letter-spacing: -0.04em;
+  font-family: var(--serif);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   color: var(--gold);
   line-height: 1;
 }
@@ -1213,10 +1276,10 @@ a.google-badge:hover {
 }
 
 .google-stars {
-  font-family: "Syne", sans-serif;
-  font-size: 20px;
-  font-weight: 700;
-  letter-spacing: -0.04em;
+  font-family: var(--serif);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   color: #4285f4;
   line-height: 1;
 }
@@ -1249,9 +1312,10 @@ a.google-badge:hover {
 
 .mobile-card-desc {
   margin: 6px 0 0;
-  font-size: 12px;
+  font-family: var(--serif);
+  font-size: 14px;
   color: var(--text-dim);
-  line-height: 1.45;
+  line-height: 1.5;
   font-style: italic;
 }
 
@@ -1280,21 +1344,22 @@ a.google-badge:hover {
 
 .focus-title {
   margin: 0;
-  font-family: "Syne", sans-serif;
-  font-size: 23px;
-  font-weight: 700;
-  letter-spacing: -0.035em;
-  line-height: 1.12;
+  font-family: var(--serif);
+  font-size: clamp(22px, 2.5vw, 28px);
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.1;
   min-width: 0;
   color: var(--text);
 }
 
 /* Love Dining card detail sections */
 .focus-name {
-  font-size: 20px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  line-height: 1.2;
+  font-family: var(--serif);
+  font-size: 22px;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.15;
   margin: 0;
 }
 
@@ -1350,25 +1415,28 @@ a.google-badge:hover {
 }
 
 .focus-summary {
-  margin: 10px 0;
-  font-size: 14px;
+  margin: 12px 0;
+  font-family: var(--serif);
+  font-size: 16px;
   color: var(--text-secondary);
-  line-height: 1.55;
+  line-height: 1.62;
 }
 
 .focus-summary-ai {
   font-style: italic;
-  opacity: 0.85;
+  color: rgba(240, 235, 226, 0.72);
 }
 
 .focus-note {
-  margin: 8px 0;
-  padding: 10px 12px;
-  border-left: 2px solid rgba(201, 165, 90, 0.4);
-  background: rgba(201, 165, 90, 0.05);
+  margin: 10px 0;
+  padding: 10px 14px;
+  border-left: 2px solid rgba(201, 165, 90, 0.35);
+  background: rgba(201, 165, 90, 0.04);
   border-radius: 0 var(--radius-xs) var(--radius-xs) 0;
+  font-family: var(--sans);
   font-size: 12px;
   color: var(--text-secondary);
+  line-height: 1.5;
 }
 
 .focus-note-warn {
@@ -1460,10 +1528,10 @@ a.google-badge:hover {
 
 .signal-rating {
   display: block;
-  font-family: "Syne", sans-serif;
-  font-size: 18px;
-  font-weight: 700;
-  letter-spacing: -0.03em;
+  font-family: var(--serif);
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: 0;
   color: var(--gold);
   text-decoration: none;
 }
@@ -1689,8 +1757,9 @@ a.google-badge:hover {
 
 .map-cta-heading {
   margin: 0;
-  font-size: 15px;
-  font-weight: 600;
+  font-family: var(--serif);
+  font-size: 18px;
+  font-weight: 500;
   color: var(--text);
 }
 
@@ -1698,6 +1767,7 @@ a.google-badge:hover {
   margin: 0;
   font-size: 12px;
   color: var(--text-dim);
+  line-height: 1.5;
 }
 
 
@@ -1730,11 +1800,12 @@ a.google-badge:hover {
 }
 
 .popup-name {
-  font-family: "Syne", sans-serif;
-  font-size: 15px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-family: var(--serif);
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: 0;
   margin-bottom: 4px;
+  line-height: 1.2;
 }
 
 .popup-card div {
@@ -1777,16 +1848,18 @@ a.google-badge:hover {
 ════════════════════════════════════════════════════════════ */
 h1, h2, h3 {
   margin: 0;
-  font-family: "Syne", "Figtree", sans-serif;
-  letter-spacing: -0.04em;
+  font-family: var(--serif);
+  letter-spacing: -0.01em;
+  font-weight: 600;
 }
 
 .eyebrow {
   margin: 0 0 6px;
   color: var(--gold);
-  font-size: 10px;
+  font-family: var(--sans);
+  font-size: 9px;
   font-weight: 700;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
 }
 
@@ -1825,11 +1898,12 @@ h1, h2, h3 {
   }
 
   .app-header {
-    margin-bottom: 10px;
+    margin-bottom: 0;
+    padding: 14px 2px 12px;
   }
 
   .app-title {
-    font-size: 15px;
+    font-size: clamp(15px, 4vw, 18px);
   }
 
   /* On mobile: show map panel only (hide focus panel), then card list below */
@@ -1877,37 +1951,55 @@ h1, h2, h3 {
   }
 
   .intro-question {
-    font-size: 28px;
+    font-size: clamp(28px, 8vw, 40px);
   }
 
   .context-strip {
     flex-direction: column;
-    gap: 6px;
+    align-items: flex-start;
+    gap: 4px;
+    padding-top: 18px;
+  }
+
+  .context-title {
+    font-size: clamp(28px, 7.5vw, 42px);
   }
 
   .summary-strip-text-inline {
     white-space: normal;
   }
 
+  /* Mobile: primary nav — tighter text tabs */
   .primary-nav {
-    gap: 5px;
+    gap: 0;
   }
 
   .primary-link {
-    font-size: 12px;
-    padding: 7px 13px;
+    font-size: 11px;
+    padding: 12px 14px 10px;
+    letter-spacing: 0.07em;
+  }
+
+  .primary-link::after {
+    left: 14px;
+    right: 14px;
   }
 
   .focus-title {
-    font-size: 19px;
+    font-size: 22px;
   }
 }
 
 /* Very small */
-@media (max-width: 480px) {
+@media (max-width: 380px) {
   .primary-link {
-    font-size: 11px;
-    padding: 7px 10px;
+    font-size: 10px;
+    padding: 11px 11px 9px;
+  }
+
+  .primary-link::after {
+    left: 11px;
+    right: 11px;
   }
 }
 
@@ -1956,10 +2048,10 @@ h1, h2, h3 {
 }
 
 .mvs-name {
-  font-family: "Syne", sans-serif;
-  font-size: 16px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-family: var(--serif);
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2007,10 +2099,7 @@ h1, h2, h3 {
     display: none;
   }
 
-  /* Reduce context title size on mobile */
-  .context-title {
-    font-size: clamp(18px, 5vw, 24px);
-  }
+  /* Reduce context title size on mobile — already handled above */
 
   /* Scope nav: swap pills → dropdown on mobile */
   #scope-strip {
@@ -2044,18 +2133,7 @@ h1, h2, h3 {
   }
 
   .mobile-results-panel .panel-head h2 {
-    font-size: 14px;
-  }
-
-  /* Mobile: primary nav pills — tighter but still pills */
-  .primary-nav {
-    gap: 4px;
-  }
-
-  .primary-link {
-    font-size: 13px;
-    padding: 8px 14px;
-    letter-spacing: -0.01em;
+    font-size: 16px;
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaces Syne with **Cormorant Garamond** across all display text — headings, titles, intro headline, descriptions, popup names, card titles
- Redesigns primary nav from pills → **editorial underline tabs** with animated gold indicator
- Intro gate headline in large italic serif — from 28px generic to 64px Cormorant italic centrepiece
- App nav redesigned as a flush masthead (removes floating glass box)
- Context section titles scaled up dramatically: `clamp(34px, 4.5vw, 56px)`
- Gold shimmer line at top of intro card, metallic box-shadow depth
- More evocative intro card copy with real venue counts
- Ghost buttons: uppercase pill style, refined gold border
- Panel top borders: subtle gold tint for premium depth
- Mobile: column layout alignment fixed, underline tabs sized correctly

## Test plan

- [ ] Verify intro gate renders at desktop (1440px) — italic serif headline, three cards, gold shimmer
- [ ] Verify intro gate on mobile (390px) — stacks cleanly, font readable
- [ ] Verify main nav tabs show active underline on each section (Dining / Plat Stay / Love Dining)
- [ ] Verify scope country pills visible and correct on dining routes
- [ ] Verify scope strip hidden on non-dining routes
- [ ] Verify restaurant name in focus panel renders in Cormorant Garamond
- [ ] Verify AI descriptions render in italic serif in focus panel
- [ ] Verify mobile dropdown works for country selection