### PR TITLE
feat: surface table for two set-menu PDFs from Amex CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ data/global-website-signals-cache.json
 data/global-dining-geocode-cache.json
 data/review-promotion-batch.json
 data/tabelog-ground-truth-sample.json
+data/tft-menus/

--- a/data/table-for-two.json
+++ b/data/table-for-two.json
@@ -4047,6 +4047,18 @@
         "avg_price": "S$48",
         "opening_hour": "Mon -Sun 12:00 - 15:00, 18:00 - 22:30",
         "website_detail_url": "https://www.diningcity.sg/singapore/15_stamford_by_alvin_leung"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/15Stamford-Menu_Platinum.pdf",
+        "filename": "15Stamford-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "b2458951e5aa7168adf37d215482a0bd32a68916eedf1b8724dd57a874efa4bc",
+        "bytes": 1309900,
+        "aem_created": "Fri Mar 13 2026 05:00:29 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -6138,6 +6150,18 @@
         "avg_price": "S$48",
         "opening_hour": "Monday Closed\nTuesday 6 pm–3 am\nWednesday 6 pm–3 am\nThursday 6 pm–3 am\nFriday 6 pm–3 am\nSaturday 6 pm–4 am\nSunday Closed",
         "website_detail_url": "https://www.diningcity.sg/singapore/Baes_Cocktail_Club"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Baes-Menu_Platinum.pdf",
+        "filename": "Baes-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "84893b90ec4f378f71bb9a44058d3c65b9071c2f1d7e1cec7c0f9b31da22015a",
+        "bytes": 193357,
+        "aem_created": "Fri Feb 27 2026 02:39:05 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -13029,6 +13053,18 @@
         "avg_price": "S$48",
         "opening_hour": "Monday 11 am–9 pm\nTuesday 11 am–9 pm\nWednesday 11 am–9 pm\nThursday 11 am–9 pm\nFriday 11 am–9 pm\nSaturday 11 am–9 pm\nSunday 11 am–9 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/Cultivate_Cafe"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Cultivate-Menu_Platinum.pdf",
+        "filename": "Cultivate-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "42c3c9d62ba48977afd46cb8e621e595b5d1c9dc1059d7ffaad597fb510496c4",
+        "bytes": 209962,
+        "aem_created": "Fri Feb 27 2026 02:32:00 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -16297,6 +16333,18 @@
         "avg_price": "S$48",
         "opening_hour": "Monday 11:30 am–11 pm\nTuesday 11:30 am–11 pm\nWednesday 11:30 am–11 pm\nThursday 11:30 am–11 pm\nFriday 11:30 am–11 pm\nSaturday 5 pm–11 pm\nSunday Closed",
         "website_detail_url": "https://www.diningcity.sg/singapore/high_house"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/HighHouse-Menu_Platinum.pdf",
+        "filename": "HighHouse-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "064b25a822f19f5f44866b3f78f7af5ae426300753dea09cbbd438b29826020c",
+        "bytes": 158690,
+        "aem_created": "Fri Feb 27 2026 02:32:17 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -19169,6 +19217,18 @@
         "avg_price": "S$48",
         "opening_hour": "Mon- Fri 12:00 - 14:30, 18:30 - 22:30. \nSat and Sun 12:30 – 15:30, 18:30 - 22:30.",
         "website_detail_url": "https://www.diningcity.sg/singapore/la_brasserie_aat3"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/La-Brasserie-Menu_Platinum.pdf",
+        "filename": "La-Brasserie-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "71e77ca5a30f05ec87966239b27492a8e216d38a6e2963fab03c1c862d525446",
+        "bytes": 158239,
+        "aem_created": "Thu Feb 05 2026 00:36:42 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -29158,6 +29218,18 @@
         "avg_price": "S$72",
         "opening_hour": "Monday 12–2:30 pm, 3–10 pm\nTuesday 12–2:30 pm, 3–10 pm\nWednesday 12–2:30 pm, 3–10 pm\nThursday 12–2:30 pm, 3–10 pm\nFriday12–2:30 pm, 3–10 pm\nSaturday 12–2:30 pm, 5–10 pm\nSunday 12–2:30 pm, 5–10 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/Osteria_Mozza"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Osteria-Mozza-Menu_Platinum.pdf",
+        "filename": "Osteria-Mozza-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "3347607d410858391fc27cd26bed019c981fdca45b1fe50f8666a5d08eeb22d9",
+        "bytes": 109793,
+        "aem_created": "Thu Feb 05 2026 00:36:18 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -29208,6 +29280,18 @@
         "avg_price": "S$88",
         "opening_hour": "Monday Closed\nTuesday 12–2:30 pm, 5–11 pm\nWednesday 12–2:30 pm, 5–11 pm\nThursday 12–2:30 pm, 5–11 pm\nFriday 12–2:30 pm, 5 pm–12 am\nSaturday 12–2:30 pm, 5 pm–12 am\nSunday Closed",
         "website_detail_url": "https://www.diningcity.sg/singapore/Polo_Bar_Steakhouse"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Polo-Bar-Steakhouse-Menu_Platinum.pdf",
+        "filename": "Polo-Bar-Steakhouse-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "b526094d8767280f2a2422bcf4744a1254ca1db22262115cd33f0bcbec8fd3be",
+        "bytes": 131635,
+        "aem_created": "Fri Jan 02 2026 03:34:24 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -32881,6 +32965,18 @@
         "avg_price": "S$70",
         "opening_hour": "Monday 6–10:30 pm\nTuesday 11:45 am–2:30 pm, 6–10:30 pm\nWednesday 11:45 am–2:30 pm, 6–10:30 pm\nThursday 11:45 am–2:30 pm, 6–10:30 pm\nFriday 11:45 am–2:30 pm, 6–10:30 pm\nSaturday 11:45 am–2:30 pm, 6–10:30 pm\nSunday 11:45 am–2:30 pm, 6–10:30 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/RAPPU"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/RAPPU-Menu_Platinum.pdf",
+        "filename": "RAPPU-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "64d400fb7fc978494d21ba945700b6c5c793c85652bd906a432c0e2979e0603f",
+        "bytes": 121250,
+        "aem_created": "Fri Feb 27 2026 02:33:32 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -40686,6 +40782,18 @@
         "avg_price": "S$58",
         "opening_hour": "Monday 11:30 am–3 pm, 5:30 pm–10:30 pm\nTuesday 11:30 am–3 pm, 5:30 pm–10:30 pm\nWednesday 11:30 am–3 pm, 5:30 pm–10:30 pm\nThursday 11:30 am–3 pm, 5:30 pm–10:30 pm\nFriday 11:30 am–3 pm, 5:30 pm–10:30 pm\nSaturday 11:30 am–3 pm, 5:30 pm–10:30 pm\nSunday 11:30 am–3 pm, 5:30 pm–10:30 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/Sarai"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/SARAI-Menu_Platinum.pdf",
+        "filename": "SARAI-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "5857fdba14b0a4f28d30dbb0ea38b228c10198d6824285cadcf9e5dc726b1506",
+        "bytes": 632698,
+        "aem_created": "Fri Feb 27 2026 02:31:28 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -44015,6 +44123,18 @@
         "avg_price": "S$88",
         "opening_hour": "Monday\t12–2:30 pm, 6–10 pm\nTuesday\t12–2:30 pm, 6–10 pm\nWednesday 12–2:30 pm, 6–10 pm\nThursday 12–2:30 pm, 6–10 pm\nFriday 12–2:30 pm, 6–10 pm\nSaturday 12–2:30 pm, 6–10 pm\nSunday 12–2:30 pm, 6–10 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/tanoke"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/TANOKE-Menu_Platinum.pdf",
+        "filename": "TANOKE-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "84e3ec492f9cb46722debc527c27ee940216d09bbfb42b451200636ab98d078e",
+        "bytes": 87299,
+        "aem_created": "Fri Jan 02 2026 07:12:42 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -49715,6 +49835,18 @@
         "avg_price": "S$38",
         "opening_hour": "Monday 5:30–10:30 pm\nTuesday 5:30–10:30 pm\nWednesday 11:45 am–2:30 pm, 5:30–10:30 pm\nThursday 11:45 am–2:30 pm, 5:30–10:30 pm\nFriday 11:45 am–2:30 pm, 5:30–10:30 pm\nSaturday 11:45 am–2:30 pm, 5:30–10:30 pm\nSunday 11:45 am–2:30 pm, 5:30–10:30 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/The_Feather_Blade"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Feather-Blade_Menu.pdf",
+        "filename": "Feather-Blade_Menu.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "95d5de1ef19d50ba38317258bec72a42f3077a76b6e9b6073e711835bcf80b9c",
+        "bytes": 1923182,
+        "aem_created": "Sat Feb 28 2026 00:48:11 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -56000,6 +56132,18 @@
         "avg_price": "S$38",
         "opening_hour": "Mon - Fri 12:00 15:00, 18:00 - 22:00. Sat and Sun 10:30 - 22:00",
         "website_detail_url": "https://www.diningcity.sg/singapore/vineyard_hort_park"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Vineyard-Menu_Platinum.pdf",
+        "filename": "Vineyard-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "195c43a9657a987f0416383887c9492b2eb72e407848d85fec1dd1a1348c3920",
+        "bytes": 1104017,
+        "aem_created": "Fri Feb 27 2026 02:31:40 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -56050,6 +56194,18 @@
         "avg_price": "S$68",
         "opening_hour": "Monday 11:30 am–2 pm, 5:30 pm–1 am\nTuesday 11:30 am–2 pm, 5:30 pm–1 am\nWednesday 11:30 am–2 pm, 5:30 pm–1 am\nThursday 11:30 am–2 pm, 5:30 pm–1 am\nFriday 11:30 am–2 pm, 5:30 pm–2 am\nSaturday 11:30 am–3 pm, 5:30 pm–2 am\nSunday Closed",
         "website_detail_url": "https://www.diningcity.sg/singapore/vue"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/VUE-Menu_Platinum.pdf",
+        "filename": "VUE-Menu_Platinum.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "d3e960e43956e93cd2471154355697f843fdf065aff8d5f511afdc46bcc42c69",
+        "bytes": 173915,
+        "aem_created": "Fri Jan 02 2026 03:33:55 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -58493,6 +58649,18 @@
         "avg_price": "S$98",
         "opening_hour": "Monday\t6:30–10:30 am, 12–2:30 pm, 3:30–5:30 pm, 6:30–10:30 pm\nTuesday\t6:30–10:30 am, 12–2:30 pm, 3:30–5:30 pm, 6:30–10:30 pm\nWednesday\t6:30–10:30 am, 12–2:30 pm, 3:30–5:30 pm, 6:30–10:30 pm\nThursday\t6:30–10:30 am, 12–2:30 pm, 3:30–5:30 pm, 6:30–10:30 pm\nFriday\t6:30–10:30 am, 12–2:30 pm, 3:30–5:30 pm, 6:30–10:30 pm\nSaturday\t6:30–10:30 am, 12–2:30 pm, 3:30–5:30 pm, 6:30–10:30 pm\nSunday\t6:30–10:30 am, 12–3:30 pm, 6:30–10:30 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/colony"
+      },
+      "menu_pdf": {
+        "status": "buffet_no_menu_expected",
+        "url": null,
+        "filename": null,
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": null,
+        "last_seen_at": null,
+        "sha256": null,
+        "bytes": null,
+        "aem_created": null,
+        "changed_at": null
       }
     },
     {
@@ -61754,6 +61922,22 @@
         "avg_price": "S$88",
         "opening_hour": "Monday 6:30 am–10 pm\nTuesday 6:30 am–10 pm\nWednesday 6:30 am–10 pm\nThursday 6:30 am–10 pm\nFriday 6:30 am–10 pm\nSaturday 6:30 am–10 pm\nSunday 6:30 am–10 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/Peppermint"
+      },
+      "app_tags": [
+        "Table for Two",
+        "Buffet"
+      ],
+      "menu_pdf": {
+        "status": "buffet_no_menu_expected",
+        "url": null,
+        "filename": null,
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": null,
+        "last_seen_at": null,
+        "sha256": null,
+        "bytes": null,
+        "aem_created": null,
+        "changed_at": null
       }
     },
     {
@@ -68364,6 +68548,18 @@
         "avg_price": "S$58",
         "opening_hour": "Monday\t8 am–10:30 pm\nTuesday\t8 am–10:30 pm\nWednesday\t8 am–10:30 pm\nThursday\t8 am–10:30 pm\nFriday\t8 am–10:30 pm\nSaturday\t8 am–10:30 pm\nSunday\t8 am–10:30 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/capitol_bistro_bar_patisserie"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/CapitolBistro-Menu.pdf",
+        "filename": "CapitolBistro-Menu.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "0e8a5ed10351cdf27b0af344698c3a963c6ba86fd499b37ea61d283021d8e759",
+        "bytes": 416896,
+        "aem_created": "Sun Jan 18 2026 22:22:23 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -82328,6 +82524,18 @@
         "avg_price": "S$48",
         "opening_hour": "Monday 7 am–11 pm\nTuesday 7 am–11 pm\nWednesday 7 am–11 pm\nThursday 7 am–11 pm\nFriday 7 am–11 pm\nSaturday 7 am–11 pm\nSunday 7 am–11 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/kees"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Kees-Menu.pdf",
+        "filename": "Kees-Menu.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "f78100d4865e6b44c15a1ad7ed559a2749db897fee30396756682594ef343bcb",
+        "bytes": 146354,
+        "aem_created": "Fri Feb 27 2026 02:38:48 GMT-0700",
+        "changed_at": null
       }
     },
     {
@@ -91026,7 +91234,28 @@
         "avg_price": "S$48",
         "opening_hour": "Monday 11:30 am–2:30 pm, 5:30–11 pm\nTuesday 11:30 am–2:30 pm, 5:30–11 pm\nWednesday 11:30 am–2:30 pm, 5:30–11 pm\nThursday 11:30 am–2:30 pm, 5:30–11 pm\nFriday 11:30 am–2:30 pm, 5:30–11 pm\nSaturday 11:30 am–2:30 pm, 5:30–11 pm\nSunday 11:30 am–2:30 pm, 5:30–11 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/theplump_frenchman"
+      },
+      "menu_pdf": {
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Plump-Frenchman_Menu.pdf",
+        "filename": "Plump-Frenchman_Menu.pdf",
+        "checked_at": "2026-04-27T13:30:18Z",
+        "first_seen_at": "2026-04-27T13:30:18Z",
+        "last_seen_at": "2026-04-27T13:30:18Z",
+        "sha256": "c08178a8d1ceccc93dba99f019278af6f8528531b78de5f9dfef74d157f614fd",
+        "bytes": 1128290,
+        "aem_created": "Fri Feb 27 2026 02:20:00 GMT-0700",
+        "changed_at": null
       }
     }
-  ]
+  ],
+  "menu_source": {
+    "aem_listing_url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining.1.json",
+    "checked_at": "2026-04-27T13:30:18Z",
+    "pdfs_in_listing": 16,
+    "venues_matched": 16,
+    "venues_buffet": 2,
+    "venues_review": 0,
+    "unmatched_pdfs": []
+  }
 }

--- a/scripts/fetch_tft_menus.py
+++ b/scripts/fetch_tft_menus.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Map Amex Table for Two venues to their published set-menu PDFs.
+
+The Amex CDN exposes a JSON directory listing of all published menus at
+``dining.1.json``. Each asset is named like ``{slug}-Menu_Platinum.pdf`` or
+``{slug}-Menu.pdf`` or ``{slug}_Menu.pdf``. This script fetches that listing,
+fuzzy-matches every PDF to a venue in ``data/table-for-two.json``, downloads
+each PDF to compute a content hash, and writes back per-venue menu metadata
+so the frontend can link straight to the official PDF.
+
+Buffet venues (e.g. Colony) legitimately have no set menu PDF; those are
+marked with ``menu_pdf_status = "buffet_no_menu_expected"`` when the venue
+carries a "Buffet" app tag, and ``"no_pdf_found"`` otherwise (review).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+AEM_LISTING_URL = (
+    "https://www.americanexpress.com/content/dam/amex/en-sg/"
+    "benefits/the-platinum-card/dining.1.json"
+)
+AEM_BASE_URL = (
+    "https://www.americanexpress.com/content/dam/amex/en-sg/"
+    "benefits/the-platinum-card/dining"
+)
+USER_AGENT = "Mozilla/5.0 (compatible; AmexDiningMap/1.0)"
+HTTP_TIMEOUT = 15
+MENU_FILENAME_RE = re.compile(r".+-?_?Menu(_Platinum)?\.pdf$", re.IGNORECASE)
+
+
+def iso_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def http_get(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+        return resp.read()
+
+
+def fetch_aem_menu_listing() -> dict[str, dict]:
+    """Return a dict of menu PDF filename -> AEM asset metadata."""
+    payload = json.loads(http_get(AEM_LISTING_URL))
+    menus = {}
+    for name, node in payload.items():
+        if not isinstance(node, dict):
+            continue
+        if node.get("jcr:primaryType") != "dam:Asset":
+            continue
+        if not MENU_FILENAME_RE.match(name):
+            continue
+        menus[name] = {
+            "filename": name,
+            "url": f"{AEM_BASE_URL}/{name}",
+            "aem_created": node.get("jcr:created"),
+            "aem_uuid": node.get("jcr:uuid"),
+        }
+    return menus
+
+
+def normalize_for_match(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def filename_stem(filename: str) -> str:
+    stem = filename
+    for suffix in ("-Menu_Platinum.pdf", "-Menu.pdf", "_Menu_Platinum.pdf", "_Menu.pdf"):
+        if stem.endswith(suffix):
+            stem = stem[: -len(suffix)]
+            break
+    return stem
+
+
+def match_venue_to_filename(venue_name: str, candidates: list[str]) -> str | None:
+    """Pick the menu filename that best matches the venue name.
+
+    Strategy: normalize both sides (lowercase alphanumerics only), then prefer
+    exact stem match, then "drop the leading 'The'" match, then first-word(s)
+    prefix match. Returns the original filename or None.
+    """
+    norm_name = normalize_for_match(venue_name)
+    norm_no_the = norm_name[3:] if norm_name.startswith("the") else norm_name
+    words = venue_name.split()
+    norm_first = normalize_for_match(words[0]) if words else ""
+    norm_first2 = normalize_for_match(" ".join(words[:2])) if len(words) > 1 else ""
+
+    by_stem: list[tuple[str, str]] = [(normalize_for_match(filename_stem(f)), f) for f in candidates]
+
+    for target in (norm_name, norm_no_the):
+        for stem, fname in by_stem:
+            if stem == target:
+                return fname
+
+    for target in (norm_first2, norm_first):
+        if not target:
+            continue
+        for stem, fname in by_stem:
+            if stem == target:
+                return fname
+
+    for stem, fname in by_stem:
+        if not stem:
+            continue
+        if stem in norm_name or norm_no_the in stem:
+            return fname
+
+    return None
+
+
+def has_buffet_tag(venue: dict) -> bool:
+    tags = venue.get("app_tags") or []
+    return any("buffet" in t.lower() for t in tags)
+
+
+def update_venue_menu(
+    venue: dict,
+    listing_entry: dict | None,
+    pdf_bytes: bytes | None,
+    checked_at: str,
+) -> None:
+    """Mutate venue in place with menu PDF metadata."""
+    previous = venue.get("menu_pdf") or {}
+
+    if listing_entry is None:
+        status = "buffet_no_menu_expected" if has_buffet_tag(venue) else "no_pdf_found"
+        venue["menu_pdf"] = {
+            "status": status,
+            "url": None,
+            "filename": None,
+            "checked_at": checked_at,
+            "first_seen_at": previous.get("first_seen_at"),
+            "last_seen_at": previous.get("last_seen_at"),
+            "sha256": None,
+            "bytes": None,
+            "aem_created": None,
+            "changed_at": previous.get("changed_at"),
+        }
+        return
+
+    sha256 = hashlib.sha256(pdf_bytes).hexdigest() if pdf_bytes is not None else previous.get("sha256")
+    size = len(pdf_bytes) if pdf_bytes is not None else previous.get("bytes")
+    prev_sha = previous.get("sha256")
+    changed_at = checked_at if (prev_sha and sha256 and prev_sha != sha256) else previous.get("changed_at")
+    first_seen = previous.get("first_seen_at") or checked_at
+
+    venue["menu_pdf"] = {
+        "status": "published",
+        "url": listing_entry["url"],
+        "filename": listing_entry["filename"],
+        "checked_at": checked_at,
+        "first_seen_at": first_seen,
+        "last_seen_at": checked_at,
+        "sha256": sha256,
+        "bytes": size,
+        "aem_created": listing_entry.get("aem_created"),
+        "changed_at": changed_at,
+    }
+
+
+def maybe_save_pdf(pdf_bytes: bytes, filename: str, cache_dir: Path) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / filename).write_bytes(pdf_bytes)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", default="data/table-for-two.json")
+    parser.add_argument("--output", default="data/table-for-two.json")
+    parser.add_argument(
+        "--cache-dir",
+        default="data/tft-menus",
+        help="Directory to save downloaded PDFs (set empty to skip).",
+    )
+    parser.add_argument(
+        "--no-download",
+        action="store_true",
+        help="Skip PDF downloads (no sha256/bytes computed; faster).",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    cache_dir = Path(args.cache_dir) if args.cache_dir else None
+
+    payload = json.loads(input_path.read_text(encoding="utf-8"))
+    venues = payload.get("venues") or []
+    if not venues:
+        print("No venues in input file.", file=sys.stderr)
+        return 1
+
+    checked_at = iso_now()
+    listing = fetch_aem_menu_listing()
+    print(f"AEM listing: {len(listing)} menu PDFs found", file=sys.stderr)
+
+    available_filenames = list(listing.keys())
+    matched_count = 0
+    buffet_count = 0
+    review_count = 0
+    matched_filenames: set[str] = set()
+
+    for venue in venues:
+        match = match_venue_to_filename(venue["name"], available_filenames)
+        entry = listing.get(match) if match else None
+
+        pdf_bytes: bytes | None = None
+        if entry and not args.no_download:
+            try:
+                pdf_bytes = http_get(entry["url"])
+                if cache_dir is not None and not args.dry_run:
+                    maybe_save_pdf(pdf_bytes, entry["filename"], cache_dir)
+            except urllib.error.URLError as exc:
+                print(f"  ! download failed for {venue['name']}: {exc}", file=sys.stderr)
+
+        update_venue_menu(venue, entry, pdf_bytes, checked_at)
+
+        info = venue["menu_pdf"]
+        if info["status"] == "published":
+            matched_count += 1
+            matched_filenames.add(entry["filename"])
+            size_str = f"{info['bytes']:,}B" if info["bytes"] else "?"
+            print(f"  OK  {venue['name']:38s}  {info['filename']:40s}  {size_str}")
+        elif info["status"] == "buffet_no_menu_expected":
+            buffet_count += 1
+            print(f"  BUF {venue['name']:38s}  (buffet — no menu PDF expected)")
+        else:
+            review_count += 1
+            print(f"  ??  {venue['name']:38s}  NO PDF FOUND — review")
+
+    unmatched = sorted(set(available_filenames) - matched_filenames)
+    if unmatched:
+        print(f"\nWARNING: {len(unmatched)} PDFs in AEM listing did not match any venue:", file=sys.stderr)
+        for f in unmatched:
+            print(f"  - {f}", file=sys.stderr)
+
+    payload["menu_source"] = {
+        "aem_listing_url": AEM_LISTING_URL,
+        "checked_at": checked_at,
+        "pdfs_in_listing": len(listing),
+        "venues_matched": matched_count,
+        "venues_buffet": buffet_count,
+        "venues_review": review_count,
+        "unmatched_pdfs": unmatched,
+    }
+
+    print(
+        f"\nMatched {matched_count}/{len(venues)} "
+        f"(buffet: {buffet_count}, review: {review_count})",
+        file=sys.stderr,
+    )
+
+    if args.dry_run:
+        print("[dry-run] not writing output file", file=sys.stderr)
+        return 0
+
+    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {output_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/app.js
+++ b/web/app.js
@@ -4560,7 +4560,7 @@ function renderTableForTwoList() {
       <p class="mobile-card-desc">${escapeHtml(tableForTwoCompactAvailabilityLine(record, filters))}</p>
       <div class="mobile-card-meta">
         <span>${escapeHtml(tableForTwoDateSummary(record, filters))}</span>
-        <span>Amex app</span>
+        <span>${record.menu_pdf?.status === "published" ? "Set menu · Amex app" : "Amex app"}</span>
       </div>
     `;
     card.addEventListener("click", () => {
@@ -4612,6 +4612,13 @@ function renderTableForTwoCard() {
   const profileSourceUrl = tableForTwoProfile(record).source_url || "";
   const gBadge = googleRatingBadge(record);
   const googleMapsUrl = bestGoogleMapsUrl(record) || googleMapsSearchUrl([displayName, "Singapore"]);
+  const menuPdf = record.menu_pdf || {};
+  const menuPdfLink = menuPdf.status === "published" && menuPdf.url
+    ? `<a class="inline-link primary-action" href="${escapeHtml(menuPdf.url)}" target="_blank" rel="noopener">View set menu (PDF)</a>`
+    : "";
+  const menuPdfNote = menuPdf.status === "buffet_no_menu_expected"
+    ? `<div class="focus-note">Buffet venue — no set menu PDF.</div>`
+    : "";
 
   tableForTwoFocusCard.innerHTML = `
     ${profileImageUrl ? `<img class="tft-venue-photo" src="${escapeHtml(profileImageUrl)}" alt="${escapeHtml(displayName)}">` : ""}
@@ -4649,8 +4656,10 @@ function renderTableForTwoCard() {
         <span>${escapeHtml(tableForTwoFreshnessLabel(record))}</span>
       </div>
     </div>
+    ${menuPdfNote}
     <div class="focus-actions">
-      <a class="inline-link primary-action" href="${escapeHtml(googleMapsUrl)}" target="_blank" rel="noopener">Search Google Maps</a>
+      ${menuPdfLink}
+      <a class="inline-link${menuPdfLink ? "" : " primary-action"}" href="${escapeHtml(googleMapsUrl)}" target="_blank" rel="noopener">Search Google Maps</a>
       ${record.dining_city_public_url ? `<a class="inline-link" href="${escapeHtml(record.dining_city_public_url)}" target="_blank" rel="noopener">Public DiningCity page</a>` : ""}
       ${record.venue_source_url && !record.dining_city_public_url ? `<a class="inline-link" href="${escapeHtml(record.venue_source_url)}" target="_blank" rel="noopener">Venue source</a>` : ""}
       ${profileSourceUrl ? `<a class="inline-link subtle" href="${escapeHtml(profileSourceUrl)}" target="_blank" rel="noopener">DiningCity profile source</a>` : ""}


### PR DESCRIPTION
## Summary

- Discovered Amex's AEM JSON directory listing at `dining.1.json` — authoritative source of every published TFT set-menu PDF.
- Added `scripts/fetch_tft_menus.py` that maps all 18 venues to their PDFs (16 published + 2 buffets), with sha256 change detection.
- UI now shows a primary "View set menu (PDF)" link on the venue focus card, and a "Set menu" indicator on list cards.
- Buffet venues (Colony, Peppermint) correctly show "no set menu PDF" instead of an empty action.

## Test plan
- [x] `python3 scripts/fetch_tft_menus.py` matches 16/16 set-menu venues, classifies 2 buffets, 0 review needed
- [x] Local server (`python3 -m http.server`) loads `web/index.html` and the focus card renders the menu link
- [ ] Click "View set menu (PDF)" on a published venue → opens the official Amex PDF in a new tab
- [ ] Switch to Colony or Peppermint → focus card shows "Buffet venue — no set menu PDF" note
- [ ] Re-run the script after a future Amex menu update — `changed_at` should populate and the link should still resolve