### PR TITLE
Harden refresh commit step + per-program changelogs

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -44,7 +44,8 @@ jobs:
             --program "Japan Dining" \
             --meta data/japan-dining-source.json \
             --data data/japan-restaurants.json \
-            --output /tmp/japan-dining-alert.md
+            --output /tmp/japan-dining-alert.md \
+            --changelog data/changelog-japan-dining.md
 
       - name: Sync Plat Stay
         env:
@@ -60,7 +61,8 @@ jobs:
             --program "Plat Stay" \
             --meta data/plat-stay-source.json \
             --data data/plat-stays.json \
-            --output /tmp/plat-stay-alert.md
+            --output /tmp/plat-stay-alert.md \
+            --changelog data/changelog-plat-stay.md
 
       - name: Commit refreshed data
         run: |

--- a/.github/workflows/refresh-global-dining.yml
+++ b/.github/workflows/refresh-global-dining.yml
@@ -45,30 +45,23 @@ jobs:
             --program "Global Dining" \
             --meta data/global-dining-source.json \
             --data data/global-restaurants.json \
-            --output /tmp/global-dining-alert.md
+            --output /tmp/global-dining-alert.md \
+            --changelog data/changelog-global-dining.md
 
       - name: Commit updated data
+        env:
+          COMMIT_MESSAGE: "chore: monthly refresh of global dining data"
+          MUST_STAGE: |
+            data/global-restaurants.json
+            data/global-dining-source.json
+            data/global-dining-geocode-cache.json
+            data/changelog-global-dining.md
+          KEEP_LOCAL_ON_CONFLICT: |
+            data/global-dining-geocode-cache.json
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add \
-            data/global-restaurants.json \
-            data/global-dining-source.json \
-            data/global-dining-geocode-cache.json
-          if git diff --staged --quiet; then
-            echo "No data changes detected."
-            exit 0
-          fi
-          git commit -m "chore: monthly refresh of global dining data"
-          for attempt in 1 2 3; do
-            git pull --rebase origin main
-            if git push origin HEAD:main; then
-              exit 0
-            fi
-            echo "Push failed on attempt ${attempt}; retrying after remote sync."
-            sleep $((attempt * 5))
-          done
-          exit 1
+          bash scripts/commit_and_push.sh
 
       - name: Open Global Dining alert issue
         if: steps.global_alert.outputs.alert_required == 'true'

--- a/.github/workflows/refresh-love-dining.yml
+++ b/.github/workflows/refresh-love-dining.yml
@@ -45,13 +45,17 @@ jobs:
             --program "Love Dining" \
             --meta data/love-dining-source.json \
             --data data/love-dining.json \
-            --output /tmp/love-dining-alert.md
+            --output /tmp/love-dining-alert.md \
+            --changelog data/changelog-love-dining.md
 
       - name: Commit refreshed Love Dining data
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add data/love-dining.json data/love-dining-source.json
+          if [ -f data/changelog-love-dining.md ]; then
+            git add data/changelog-love-dining.md
+          fi
           if git diff --cached --quiet; then
             echo "No Love Dining changes detected."
             exit 0

--- a/.github/workflows/refresh-table-for-two.yml
+++ b/.github/workflows/refresh-table-for-two.yml
@@ -39,13 +39,17 @@ jobs:
             --program "Table for Two" \
             --meta data/table-for-two.json \
             --data data/table-for-two.json \
-            --output /tmp/table-for-two-alert.md
+            --output /tmp/table-for-two-alert.md \
+            --changelog data/changelog-table-for-two.md
 
       - name: Commit refreshed Table for Two data
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add data/table-for-two.json
+          if [ -f data/changelog-table-for-two.md ]; then
+            git add data/changelog-table-for-two.md
+          fi
           if git diff --cached --quiet; then
             echo "No Table for Two changes detected."
             exit 0

--- a/scripts/commit_and_push.sh
+++ b/scripts/commit_and_push.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Stage allowlisted files, commit, and push to main with a robust rebase loop.
+#
+# Behaviour:
+#   - Existing files in MUST_STAGE are added; missing paths are skipped (logged).
+#   - If nothing is staged, exits 0 (no-op).
+#   - On rebase conflicts confined to KEEP_LOCAL_ON_CONFLICT files, takes ours and
+#     continues. Conflicts touching anything else fail loudly.
+#   - Up to MAX_ATTEMPTS pull/push cycles, with linear backoff between attempts.
+#
+# Required env:
+#   COMMIT_MESSAGE        - commit message
+#   MUST_STAGE            - newline-separated list of paths to git add
+# Optional env:
+#   KEEP_LOCAL_ON_CONFLICT     - newline-separated list of paths where rebase conflicts
+#                           are auto-resolved with `--ours`
+#   MAX_ATTEMPTS          - default 3
+#   REMOTE                - default origin
+#   BRANCH                - default main
+
+set -uo pipefail
+
+REMOTE="${REMOTE:-origin}"
+BRANCH="${BRANCH:-main}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+
+if [[ -z "${COMMIT_MESSAGE:-}" ]]; then
+  echo "commit_and_push: COMMIT_MESSAGE is required" >&2
+  exit 2
+fi
+if [[ -z "${MUST_STAGE:-}" ]]; then
+  echo "commit_and_push: MUST_STAGE is required" >&2
+  exit 2
+fi
+
+mapfile -t stage_paths < <(printf '%s\n' "$MUST_STAGE" | sed '/^[[:space:]]*$/d')
+mapfile -t keep_local < <(printf '%s\n' "${KEEP_LOCAL_ON_CONFLICT:-}" | sed '/^[[:space:]]*$/d')
+
+# Stage existing files only; skip missing.
+staged_any=0
+for path in "${stage_paths[@]}"; do
+  if [[ -e "$path" ]]; then
+    git add -- "$path"
+    staged_any=1
+  else
+    echo "commit_and_push: skipping missing path $path"
+  fi
+done
+
+if [[ "$staged_any" -eq 0 ]]; then
+  echo "commit_and_push: no listed paths exist; nothing to do."
+  exit 0
+fi
+
+if git diff --cached --quiet; then
+  echo "commit_and_push: no staged changes; nothing to commit."
+  exit 0
+fi
+
+git commit -m "$COMMIT_MESSAGE"
+
+is_keep_local() {
+  local candidate="$1"
+  local p
+  for p in "${keep_local[@]}"; do
+    if [[ "$candidate" == "$p" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+resolve_rebase_conflicts() {
+  # Returns 0 if rebase was completed (or already not in progress), 1 if a
+  # conflict outside the keep-local allowlist remained.
+  if [[ ! -d .git/rebase-merge && ! -d .git/rebase-apply ]]; then
+    return 0
+  fi
+  while true; do
+    mapfile -t conflicts < <(git diff --name-only --diff-filter=U)
+    if [[ ${#conflicts[@]} -eq 0 ]]; then
+      break
+    fi
+    for f in "${conflicts[@]}"; do
+      if is_keep_local "$f"; then
+        # During a rebase, --theirs is the branch being rebased (our local
+        # commit, i.e. the workflow's freshly-generated content). --ours
+        # would pick upstream, which is the opposite of what we want.
+        echo "commit_and_push: auto-resolving rebase conflict for $f (keeping workflow output)"
+        git checkout --theirs -- "$f"
+        git add -- "$f"
+      else
+        echo "commit_and_push: unresolved conflict in $f; aborting rebase." >&2
+        git rebase --abort || true
+        return 1
+      fi
+    done
+    if ! git -c core.editor=true rebase --continue; then
+      # Another set of conflicts may have surfaced; loop again.
+      continue
+    fi
+    break
+  done
+  return 0
+}
+
+attempt=1
+while (( attempt <= MAX_ATTEMPTS )); do
+  echo "commit_and_push: attempt ${attempt}/${MAX_ATTEMPTS}: pulling $REMOTE/$BRANCH"
+  if ! git pull --rebase "$REMOTE" "$BRANCH"; then
+    if ! resolve_rebase_conflicts; then
+      exit 1
+    fi
+  fi
+
+  if git push "$REMOTE" "HEAD:$BRANCH"; then
+    echo "commit_and_push: push succeeded on attempt ${attempt}."
+    exit 0
+  fi
+
+  echo "commit_and_push: push failed on attempt ${attempt}; retrying."
+  sleep $(( attempt * 5 ))
+  attempt=$(( attempt + 1 ))
+done
+
+echo "commit_and_push: exhausted ${MAX_ATTEMPTS} attempts." >&2
+exit 1

--- a/scripts/source_change_alert.py
+++ b/scripts/source_change_alert.py
@@ -26,6 +26,18 @@ IGNORED_RECORD_FIELDS = {
     "last_synced_at",
     "last_verified_at",
     "availability",
+    "slot_source_status",
+}
+
+# Nested keys (under any dict, at any depth) that flip every scrape but do not
+# represent a real change to the venue. Stripped before hashing.
+IGNORED_NESTED_KEYS = {
+    "captured_at",
+    "checked_at",
+    "fetched_at",
+    "last_checked_at",
+    "last_synced_at",
+    "last_verified_at",
 }
 
 META_FIELD_LABELS = {
@@ -97,9 +109,21 @@ def record_label(record: dict[str, Any]) -> str:
     return " / ".join(str(part) for part in parts if part)
 
 
+def _strip_nested(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _strip_nested(sub)
+            for key, sub in value.items()
+            if key not in IGNORED_NESTED_KEYS
+        }
+    if isinstance(value, list):
+        return [_strip_nested(item) for item in value]
+    return value
+
+
 def stable_record_hash(record: dict[str, Any]) -> str:
     cleaned = {
-        key: value
+        key: _strip_nested(value)
         for key, value in record.items()
         if key not in IGNORED_RECORD_FIELDS
     }
@@ -138,12 +162,54 @@ def format_limited(items: list[str], limit: int = 12) -> list[str]:
     return items[:limit] + [f"... and {len(items) - limit} more"]
 
 
+def append_changelog(
+    changelog_path: Path,
+    program: str,
+    record_diffs: list[tuple[str, dict[str, list[str]]]],
+) -> None:
+    """Append a dated entry to the per-program changelog.
+
+    Only logs additions and removals — those are the interesting events
+    (new venues, dropped venues). Field-level changes are intentionally
+    omitted; they're noisy and most useful in the issue body, not a
+    permanent log.
+    """
+    has_changes = any(diff["added"] or diff["removed"] for _, diff in record_diffs)
+    if not has_changes:
+        return
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines: list[str] = [f"## {timestamp} — {program}", ""]
+    for data_path, diff in record_diffs:
+        if not (diff["added"] or diff["removed"]):
+            continue
+        lines.append(f"Source: `{data_path}`")
+        lines.append("")
+        for key, title in (("added", "Added"), ("removed", "Removed")):
+            items = diff[key]
+            if not items:
+                continue
+            lines.append(f"- **{title} ({len(items)})**")
+            lines.extend(f"  - {item}" for item in format_limited(items, limit=50))
+        lines.append("")
+
+    if changelog_path.exists():
+        existing = changelog_path.read_text(encoding="utf-8").rstrip() + "\n\n"
+    else:
+        existing = f"# {program} change log\n\n"
+    changelog_path.write_text(existing + "\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--program", required=True)
     parser.add_argument("--meta", required=True)
     parser.add_argument("--data", action="append", default=[])
     parser.add_argument("--output", required=True)
+    parser.add_argument(
+        "--changelog",
+        help="Append a dated entry to this changelog file when records changed.",
+    )
     args = parser.parse_args()
 
     current_meta = load_json(args.meta)
@@ -179,6 +245,9 @@ def main() -> int:
 
     alert_required = bool(reasons or record_diffs)
     append_output("alert_required", "true" if alert_required else "false")
+
+    if args.changelog:
+        append_changelog(Path(args.changelog), args.program, record_diffs)
 
     lines = [
         f"# {args.program} source changed" if alert_required else f"# {args.program} source unchanged",


### PR DESCRIPTION
## Summary
- The `Refresh Global Dining Data` "Commit updated data" step was failing in 1 second because `git add` on a gitignored path (`data/global-dining-snapshot.json`) returns exit 1 under `set -e`. The immediate cause is already patched on `main` (`ed9d9ff`); this PR adds defense in depth.
- New `scripts/commit_and_push.sh` replaces the inline retry shell. Runs without `set -e`, skips `MUST_STAGE` paths that aren't on disk, and on rebase conflicts limited to a `KEEP_LOCAL_ON_CONFLICT` allowlist keeps the workflow's freshly-generated content (using `--theirs`, since during a rebase that points at the local commit). Conflicts touching anything else fail loudly.
- New `--changelog <path>` flag on `scripts/source_change_alert.py` writes a dated entry to a per-program changelog (`data/changelog-<program>.md`) when records were added or removed. Field-level "changed" diffs are intentionally omitted — those stay in the alert/issue, not the persisted log.
- Hash now strips nested timestamp keys (`captured_at`, `checked_at`, etc.) so volatile timestamps inside profiles don't trigger spurious "changed" entries (especially relevant for Table for Two seat availability churn).
- All four refresh workflows pass `--changelog` and stage the file when it exists. Only `refresh-global-dining` switches to the new helper for now — the other three already commit reliably.

## Confirmed root cause
From the failing run's log:
```
The following paths are ignored by one of your .gitignore files:
data/global-dining-snapshot.json
##[error]Process completed with exit code 1.
```
The shell line `shell: /usr/bin/bash -e {0}` confirms `set -e` was active. `ed9d9ff` removed that path from `git add` and the next run produced `bf7aa9d` successfully.

## Test plan
- [x] `bash -n scripts/commit_and_push.sh` (syntax check)
- [x] `python3 -c "import yaml; ..."` parses all four edited workflows cleanly
- [x] Unit-tested `append_changelog`: first/second append, no-op when nothing changed
- [x] Unit-tested `stable_record_hash`: nested `captured_at` ignored, real cuisine change detected, `availability` and `slot_source_status` ignored
- [x] End-to-end test of `commit_and_push.sh` in throwaway git repos: missing path skipped, conflict on cache file auto-resolved keeping the local workflow output, real-data file rebased cleanly, push succeeded
- [ ] Real CI run on the global-dining workflow against `claude/new-session-Cbbef` (you to trigger via Actions UI → Run workflow → branch `claude/new-session-Cbbef`)

https://claude.ai/code/session_01PA7ZtbjvDHmPpuWXaNdEka

---
_Generated by [Claude Code](https://claude.ai/code/session_01PA7ZtbjvDHmPpuWXaNdEka)_