### PR TITLE
feat: multi-venue + specific dates + confirm-email match note

### DIFF
--- a/reminders/.env.example
+++ b/reminders/.env.example
@@ -6,3 +6,4 @@ ALERT_EXPORT_TOKEN=YOUR_EXPORT_TOKEN
 ALLOWED_ORIGIN=https://amex-explorer.kooexperience.com
 PUBLIC_BASE_URL=http://localhost:8000
 CONFIRM_TOKEN_EXPIRY_HOURS=168
+TABLE_DATA_URL=https://amex-explorer.kooexperience.com/data/table-for-two.json

--- a/reminders/app/availability.py
+++ b/reminders/app/availability.py
@@ -1,0 +1,42 @@
+"""Coarse 'are there already open tables?' check for the confirm email.
+
+Deliberately venue+session level only — not the full slot/date/party matcher
+that the alert job runs. Good enough to add urgency to the confirm email
+without duplicating the matching pipeline. Fails closed (returns False) if the
+data can't be fetched.
+
+# ponytail: coarse by design; the precise match still happens in the alert job.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+
+def open_tables_exist(
+    venues: list[str], sessions: list[str], data_url: str, timeout: int = 4
+) -> bool:
+    try:
+        with urllib.request.urlopen(data_url, timeout=timeout) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return False
+
+    want_any = not venues or any(item.lower() == "any" for item in venues)
+    want_venues = {item.lower() for item in venues}
+    want_sessions = {item.lower() for item in sessions}
+    for venue in data.get("venues", []):
+        availability = venue.get("availability") or {}
+        if availability.get("status") != "live_available":
+            continue
+        name = str(venue.get("name") or "").lower()
+        if not want_any and name not in want_venues:
+            continue
+        for meal in availability.get("meals") or []:
+            if meal.get("status") != "available":
+                continue
+            if not want_sessions or str(meal.get("meal") or "").lower() in want_sessions:
+                return True
+    return False

--- a/reminders/app/config.py
+++ b/reminders/app/config.py
@@ -16,6 +16,7 @@ class Settings:
     allowed_origin: str
     public_base_url: str
     confirm_token_expiry_hours: int
+    table_data_url: str
 
 
 def load_settings() -> Settings:
@@ -29,4 +30,8 @@ def load_settings() -> Settings:
         ).strip(),
         public_base_url=os.getenv("PUBLIC_BASE_URL", "http://localhost:8000").rstrip("/"),
         confirm_token_expiry_hours=int(os.getenv("CONFIRM_TOKEN_EXPIRY_HOURS", "168")),
+        table_data_url=os.getenv(
+            "TABLE_DATA_URL",
+            "https://amex-explorer.kooexperience.com/data/table-for-two.json",
+        ).strip(),
     )

--- a/reminders/app/db.py
+++ b/reminders/app/db.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import secrets
 import sqlite3
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS subscribers (
   venues TEXT NOT NULL,
   date_start TEXT NOT NULL,
   date_end TEXT NOT NULL,
+  dates TEXT NOT NULL DEFAULT '[]',
   status TEXT NOT NULL DEFAULT 'pending',
   confirm_token TEXT,
   confirm_token_expires_ts TEXT,
@@ -51,6 +52,7 @@ class SubscriberInput:
     venues: list[str]
     date_start: str
     date_end: str
+    dates: list[str] = field(default_factory=list)
 
 
 def _now() -> datetime:
@@ -84,6 +86,14 @@ def init_db(path: Path | str) -> None:
     conn = connect(path)
     try:
         conn.executescript(SCHEMA)
+        columns = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(subscribers)").fetchall()
+        }
+        if "dates" not in columns:  # migrate older DBs created before specific dates
+            conn.execute(
+                "ALTER TABLE subscribers ADD COLUMN dates TEXT NOT NULL DEFAULT '[]'"
+            )
         conn.commit()
     finally:
         conn.close()
@@ -106,6 +116,7 @@ def upsert_pending(
     now_iso = _iso(now)
     sessions = json.dumps(sub.sessions)
     venues = json.dumps(sub.venues)
+    dates = json.dumps(sub.dates)
     existing = conn.execute(
         "SELECT id FROM subscribers WHERE email = ?", (sub.email,)
     ).fetchone()
@@ -114,14 +125,14 @@ def upsert_pending(
             """
             UPDATE subscribers
             SET name = ?, party_size = ?, sessions = ?, venues = ?,
-                date_start = ?, date_end = ?, status = 'pending',
+                date_start = ?, date_end = ?, dates = ?, status = 'pending',
                 confirm_token = ?, confirm_token_expires_ts = ?, source_ip = ?,
                 created_ts = ?, confirmed_ts = NULL, unsubscribed_ts = NULL
             WHERE id = ?
             """,
             (
                 sub.name, sub.party_size, sessions, venues, sub.date_start,
-                sub.date_end, confirm_token, confirm_expires, ip, now_iso,
+                sub.date_end, dates, confirm_token, confirm_expires, ip, now_iso,
                 existing["id"],
             ),
         )
@@ -130,13 +141,13 @@ def upsert_pending(
             """
             INSERT INTO subscribers (
                 email, name, party_size, sessions, venues, date_start, date_end,
-                status, confirm_token, confirm_token_expires_ts, unsubscribe_token,
-                source_ip, created_ts
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)
+                dates, status, confirm_token, confirm_token_expires_ts,
+                unsubscribe_token, source_ip, created_ts
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)
             """,
             (
                 sub.email, sub.name, sub.party_size, sessions, venues,
-                sub.date_start, sub.date_end, confirm_token, confirm_expires,
+                sub.date_start, sub.date_end, dates, confirm_token, confirm_expires,
                 new_token(), ip, now_iso,
             ),
         )
@@ -178,7 +189,7 @@ def active_subscribers(conn: sqlite3.Connection) -> list[dict]:
     rows = conn.execute(
         """
         SELECT email, name, party_size, sessions, venues, date_start, date_end,
-               unsubscribe_token
+               dates, unsubscribe_token
         FROM subscribers WHERE status = 'active' ORDER BY id
         """
     ).fetchall()
@@ -191,6 +202,7 @@ def active_subscribers(conn: sqlite3.Connection) -> list[dict]:
             "venues": json.loads(row["venues"]),
             "date_start": row["date_start"],
             "date_end": row["date_end"],
+            "dates": json.loads(row["dates"]),
             "unsubscribe_token": row["unsubscribe_token"],
         }
         for row in rows
@@ -203,7 +215,8 @@ def get_by_unsubscribe_token(conn: sqlite3.Connection, token: str) -> dict | Non
         return None
     row = conn.execute(
         """
-        SELECT email, name, party_size, sessions, venues, date_start, date_end, status
+        SELECT email, name, party_size, sessions, venues, date_start, date_end,
+               dates, status
         FROM subscribers WHERE unsubscribe_token = ?
         """,
         (token,),
@@ -218,6 +231,7 @@ def get_by_unsubscribe_token(conn: sqlite3.Connection, token: str) -> dict | Non
         "venues": json.loads(row["venues"]),
         "date_start": row["date_start"],
         "date_end": row["date_end"],
+        "dates": json.loads(row["dates"]),
         "status": row["status"],
     }
 
@@ -232,12 +246,12 @@ def update_preferences(
         """
         UPDATE subscribers
         SET name = ?, party_size = ?, sessions = ?, venues = ?,
-            date_start = ?, date_end = ?
+            date_start = ?, date_end = ?, dates = ?
         WHERE unsubscribe_token = ? AND status != 'unsubscribed'
         """,
         (
             sub.name, sub.party_size, json.dumps(sub.sessions), json.dumps(sub.venues),
-            sub.date_start, sub.date_end, token,
+            sub.date_start, sub.date_end, json.dumps(sub.dates), token,
         ),
     )
     conn.commit()

--- a/reminders/app/emailer.py
+++ b/reminders/app/emailer.py
@@ -75,9 +75,19 @@ def confirm_email_html(
     confirm_url: str,
     unsubscribe_url: str,
     manage_url: str | None = None,
+    matches_exist: bool = False,
 ) -> str:
     greeting = f"Hi {name}," if name else "Hi,"
+    good_news = (
+        '<p style="font-size:15px;line-height:1.5;margin:0 0 16px;padding:10px 12px;'
+        "background:#eaf7f3;border-radius:8px;color:#0f5132\">\U0001f389 Good news — "
+        "there are already open tables at venues you picked. Confirm to start getting "
+        "matched.</p>"
+        if matches_exist
+        else ""
+    )
     body = f"""\
+  {good_news}
   <p style="font-size:15px;line-height:1.5;margin:0 0 16px">{greeting} please confirm
      your email to start receiving Table for Two availability reminders.</p>
   <p style="margin:0 0 20px">

--- a/reminders/app/routes.py
+++ b/reminders/app/routes.py
@@ -174,6 +174,15 @@ _MANAGE_TEMPLATE = """<!doctype html>
    border:1px solid rgba(255,255,255,.12);border-radius:10px;background:#070d16}
  .venuelist label{flex-direction:row;align-items:center;gap:8px;font-size:13px;color:#e8edf5;font-weight:500}
  .venuelist input{width:auto;accent-color:#4db8a6}
+ .dateadder{display:flex;gap:8px}
+ .dateadder input{flex:1;min-width:0}
+ .dateadder button{flex:none;padding:0 14px;font-size:13px}
+ .datechips{display:flex;flex-wrap:wrap;gap:6px;margin-top:6px}
+ .datechips:empty{display:none}
+ .datechip{display:inline-flex;align-items:center;gap:4px;padding:4px 4px 4px 9px;font-size:12px;
+   color:#e8edf5;background:rgba(15,27,43,.7);border:1px solid rgba(255,255,255,.12);border-radius:999px}
+ .datechip button{border:none;background:none;color:#8a94a6;font-size:15px;line-height:1;cursor:pointer;padding:0 4px}
+ .hint{margin:6px 0 0;font-size:11px;color:#8a94a6}
 </style></head><body><div class="card">
 <h1>Your Table for Two reminders</h1>
 <p class="sub">__EMAIL__</p>
@@ -191,6 +200,11 @@ __STATUS_NOTE__
  </div></fieldset>
  <label>From<input id="m_start" type="date" value="__START__" min="__TODAY__"></label>
  <label>To<input id="m_end" type="date" value="__END__" min="__TODAY__"></label>
+ <fieldset><legend>Specific dates (optional)</legend>
+   <div class="dateadder"><input type="date" id="m_date_pick"><button type="button" id="m_date_add">Add</button></div>
+   <div class="datechips" id="m_date_chips">__DATE_CHIPS__</div>
+   <p class="hint">Leave empty for any date in the range above.</p>
+ </fieldset>
  <button type="submit">Save changes</button>
  <p id="status" class="status"></p>
 </form>
@@ -199,13 +213,23 @@ __STATUS_NOTE__
 var mList=document.getElementById('m_venue_list'), mAny=document.getElementById('m_any');
 if(mList){mList.addEventListener('change',function(){if(mAny)mAny.checked=mList.querySelectorAll('.m_venue_cb:checked').length===0;});}
 if(mAny){mAny.addEventListener('change',function(){if(mAny.checked){Array.prototype.slice.call(mList.querySelectorAll('.m_venue_cb:checked')).forEach(function(c){c.checked=false;});}});}
+var dPick=document.getElementById('m_date_pick'), dAdd=document.getElementById('m_date_add'), dChips=document.getElementById('m_date_chips');
+if(dAdd){dAdd.addEventListener('click',function(){
+ var v=dPick.value; if(!v) return;
+ var have=Array.prototype.slice.call(dChips.querySelectorAll('.datechip')).map(function(c){return c.dataset.value;});
+ if(have.indexOf(v)>=0) return;
+ var c=document.createElement('span'); c.className='datechip'; c.dataset.value=v; c.textContent=v+' ';
+ var b=document.createElement('button'); b.type='button'; b.textContent='×'; b.addEventListener('click',function(){c.remove();});
+ c.appendChild(b); dChips.appendChild(c); dPick.value='';
+});}
 document.getElementById('mform').addEventListener('submit', async function(e){
  e.preventDefault();
  var sessions = Array.prototype.slice.call(document.querySelectorAll('input[name=session]:checked')).map(function(x){return x.value;});
  var venues = Array.prototype.slice.call(document.querySelectorAll('.m_venue_cb:checked')).map(function(x){return x.value;});
+ var dates = Array.prototype.slice.call(document.querySelectorAll('.datechip')).map(function(c){return c.dataset.value;});
  var body = {name:(document.getElementById('m_name').value||'').trim()||null,
    party_size:Number(document.getElementById('m_party').value||2),sessions:sessions,
-   venues:venues.length?venues:['any'],
+   venues:venues.length?venues:['any'],dates:dates,
    date_start:document.getElementById('m_start').value,date_end:document.getElementById('m_end').value};
  var s=document.getElementById('status'); s.textContent='Saving…'; s.className='status';
  try{
@@ -228,6 +252,11 @@ def _manage_page(record: dict, token: str, base: str, venue_names: list[str]) ->
             f'<label><input type="checkbox" class="m_venue_cb" '
             f'value="{html_escape(name)}"{checked}> {html_escape(name)}</label>'
         )
+    date_chips = "".join(
+        f'<span class="datechip" data-value="{html_escape(value)}">{html_escape(value)} '
+        f'<button type="button" onclick="this.parentNode.remove()">×</button></span>'
+        for value in record.get("dates", [])
+    )
     note = ""
     if record["status"] == "pending":
         note = (
@@ -240,6 +269,7 @@ def _manage_page(record: dict, token: str, base: str, venue_names: list[str]) ->
         "__PARTY__": str(record["party_size"]),
         "__VENUE_CHECKBOXES__": "".join(checkboxes),
         "__ANY_CHECKED__": "checked" if any_selected else "",
+        "__DATE_CHIPS__": date_chips,
         "__LUNCH__": "checked" if "Lunch" in record["sessions"] else "",
         "__DINNER__": "checked" if "Dinner" in record["sessions"] else "",
         "__START__": html_escape(record["date_start"]),

--- a/reminders/app/routes.py
+++ b/reminders/app/routes.py
@@ -168,6 +168,12 @@ _MANAGE_TEMPLATE = """<!doctype html>
  .status{font-size:13px;color:#4db8a6;margin:0}
  .status.err{color:#ff8585}
  .unsub{display:inline-block;margin-top:18px;color:#8a94a6;font-size:13px}
+ .vany{flex-direction:row;align-items:center;gap:6px;font-size:14px;color:#e8edf5;font-weight:500}
+ .vany input{width:auto;accent-color:#4db8a6}
+ .venuelist{display:grid;gap:6px;max-height:140px;overflow-y:auto;padding:8px 10px;margin-top:6px;
+   border:1px solid rgba(255,255,255,.12);border-radius:10px;background:#070d16}
+ .venuelist label{flex-direction:row;align-items:center;gap:8px;font-size:13px;color:#e8edf5;font-weight:500}
+ .venuelist input{width:auto;accent-color:#4db8a6}
 </style></head><body><div class="card">
 <h1>Your Table for Two reminders</h1>
 <p class="sub">__EMAIL__</p>
@@ -175,7 +181,10 @@ __STATUS_NOTE__
 <form id="mform">
  <label>Name<input id="m_name" type="text" value="__NAME__" placeholder="Your name"></label>
  <label>Party size<input id="m_party" type="number" min="1" max="20" value="__PARTY__"></label>
- <label>Venue<select id="m_venue">__VENUE_OPTIONS__</select></label>
+ <fieldset><legend>Venues</legend>
+   <label class="vany"><input type="checkbox" id="m_any" __ANY_CHECKED__> Any venue</label>
+   <div class="venuelist" id="m_venue_list">__VENUE_CHECKBOXES__</div>
+ </fieldset>
  <fieldset><legend>Session</legend><div class="checks">
    <label><input type="checkbox" name="session" value="Lunch" __LUNCH__> Lunch</label>
    <label><input type="checkbox" name="session" value="Dinner" __DINNER__> Dinner</label>
@@ -187,12 +196,16 @@ __STATUS_NOTE__
 </form>
 <a class="unsub" href="__BASE__/api/unsubscribe?token=__TOKEN__">Unsubscribe from all reminders</a>
 <script>
+var mList=document.getElementById('m_venue_list'), mAny=document.getElementById('m_any');
+if(mList){mList.addEventListener('change',function(){if(mAny)mAny.checked=mList.querySelectorAll('.m_venue_cb:checked').length===0;});}
+if(mAny){mAny.addEventListener('change',function(){if(mAny.checked){Array.prototype.slice.call(mList.querySelectorAll('.m_venue_cb:checked')).forEach(function(c){c.checked=false;});}});}
 document.getElementById('mform').addEventListener('submit', async function(e){
  e.preventDefault();
  var sessions = Array.prototype.slice.call(document.querySelectorAll('input[name=session]:checked')).map(function(x){return x.value;});
+ var venues = Array.prototype.slice.call(document.querySelectorAll('.m_venue_cb:checked')).map(function(x){return x.value;});
  var body = {name:(document.getElementById('m_name').value||'').trim()||null,
    party_size:Number(document.getElementById('m_party').value||2),sessions:sessions,
-   venues:[document.getElementById('m_venue').value],
+   venues:venues.length?venues:['any'],
    date_start:document.getElementById('m_start').value,date_end:document.getElementById('m_end').value};
  var s=document.getElementById('status'); s.textContent='Saving…'; s.className='status';
  try{
@@ -206,13 +219,15 @@ document.getElementById('mform').addEventListener('submit', async function(e){
 
 
 def _manage_page(record: dict, token: str, base: str, venue_names: list[str]) -> str:
-    selected_venue = record["venues"][0] if record["venues"] else "any"
-    options = [
-        f'<option value="any"{" selected" if selected_venue == "any" else ""}>Any venue</option>'
-    ]
+    selected = set(record["venues"])
+    any_selected = "any" in selected or not selected
+    checkboxes = []
     for name in venue_names:
-        chosen = " selected" if name == selected_venue else ""
-        options.append(f'<option value="{html_escape(name)}"{chosen}>{html_escape(name)}</option>')
+        checked = " checked" if name in selected else ""
+        checkboxes.append(
+            f'<label><input type="checkbox" class="m_venue_cb" '
+            f'value="{html_escape(name)}"{checked}> {html_escape(name)}</label>'
+        )
     note = ""
     if record["status"] == "pending":
         note = (
@@ -223,7 +238,8 @@ def _manage_page(record: dict, token: str, base: str, venue_names: list[str]) ->
         "__EMAIL__": html_escape(record["email"]),
         "__NAME__": html_escape(record["name"] or ""),
         "__PARTY__": str(record["party_size"]),
-        "__VENUE_OPTIONS__": "".join(options),
+        "__VENUE_CHECKBOXES__": "".join(checkboxes),
+        "__ANY_CHECKED__": "checked" if any_selected else "",
         "__LUNCH__": "checked" if "Lunch" in record["sessions"] else "",
         "__DINNER__": "checked" if "Dinner" in record["sessions"] else "",
         "__START__": html_escape(record["date_start"]),

--- a/reminders/app/routes.py
+++ b/reminders/app/routes.py
@@ -12,6 +12,7 @@ from fastapi.responses import HTMLResponse
 from pydantic import ValidationError
 
 from app import db
+from app.availability import open_tables_exist
 from app.config import Settings, load_settings
 from app.emailer import confirm_email_html, send_email
 from app.schemas import VENUES_PATH, SubscribeRequest
@@ -83,10 +84,15 @@ def subscribe(
     confirm_url = f"{settings.public_base_url}/api/confirm?token={confirm_token}"
     unsub_url = f"{settings.public_base_url}/api/unsubscribe?token={unsub_token}"
     manage_url = f"{settings.public_base_url}/api/manage?token={unsub_token}"
+    matches_exist = open_tables_exist(
+        sub_input.venues, sub_input.sessions, settings.table_data_url
+    )
     send_email(
         sub_input.email,
         "Confirm your Table for Two reminders",
-        confirm_email_html(sub_input.name, confirm_url, unsub_url, manage_url),
+        confirm_email_html(
+            sub_input.name, confirm_url, unsub_url, manage_url, matches_exist
+        ),
         api_key=settings.resend_api_key,
         sender=settings.resend_from,
         list_unsubscribe_url=unsub_url,

--- a/reminders/app/schemas.py
+++ b/reminders/app/schemas.py
@@ -35,6 +35,7 @@ class SubscribeRequest(BaseModel):
     venues: list[str]
     date_start: date
     date_end: date
+    dates: list[date] = []  # optional specific dates; empty = match the whole range
     website: str = ""  # honeypot — handled in the route, not validated here
 
     @field_validator("party_size")
@@ -72,15 +73,27 @@ class SubscribeRequest(BaseModel):
                 raise ValueError(f"unknown venue(s): {', '.join(unknown)}")
         return list(dict.fromkeys(cleaned))
 
+    @field_validator("dates")
+    @classmethod
+    def _specific_dates(cls, value: list[date]) -> list[date]:
+        unique = sorted(dict.fromkeys(value))
+        if len(unique) > 31:
+            raise ValueError("pick at most 31 specific dates")
+        return unique
+
     @model_validator(mode="after")
-    def _dates(self) -> "SubscribeRequest":
+    def _dates_window(self) -> "SubscribeRequest":
         today = date.today()
+        horizon = today + timedelta(days=MAX_HORIZON_DAYS)
         if self.date_start > self.date_end:
             raise ValueError("date_start must be on or before date_end")
         if self.date_start < today:
             raise ValueError("date_start must not be in the past")
-        if self.date_end > today + timedelta(days=MAX_HORIZON_DAYS):
+        if self.date_end > horizon:
             raise ValueError(f"date_end must be within {MAX_HORIZON_DAYS} days")
+        for value in self.dates:
+            if value < today or value > horizon:
+                raise ValueError(f"each date must be within {MAX_HORIZON_DAYS} days")
         return self
 
     def to_input(self) -> SubscriberInput:
@@ -92,4 +105,5 @@ class SubscribeRequest(BaseModel):
             venues=self.venues,
             date_start=self.date_start.isoformat(),
             date_end=self.date_end.isoformat(),
+            dates=[value.isoformat() for value in self.dates],
         )

--- a/reminders/tests/test_api.py
+++ b/reminders/tests/test_api.py
@@ -38,10 +38,12 @@ def client(tmp_path: Path, monkeypatch):
         allowed_origin="https://amex-explorer.kooexperience.com",
         public_base_url="https://svc",
         confirm_token_expiry_hours=168,
+        table_data_url="http://example.invalid/data.json",
     )
     app.dependency_overrides[get_settings] = lambda: test_settings
     sent: list = []
     monkeypatch.setattr(routes, "send_email", lambda *a, **k: sent.append((a, k)))
+    monkeypatch.setattr(routes, "open_tables_exist", lambda *a, **k: False)
 
     test_client = TestClient(app)
     test_client.sent = sent  # type: ignore[attr-defined]

--- a/reminders/tests/test_availability.py
+++ b/reminders/tests/test_availability.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+
+from app import availability
+
+
+class _Resp:
+    def __init__(self, payload: dict):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+_DATA = {
+    "venues": [
+        {
+            "name": "15 Stamford Restaurant",
+            "availability": {
+                "status": "live_available",
+                "meals": [{"meal": "Dinner", "status": "available"}],
+            },
+        },
+        {
+            "name": "Cultivate",
+            "availability": {"status": "no_availability", "meals": []},
+        },
+    ]
+}
+
+
+def _patch(monkeypatch, payload):
+    monkeypatch.setattr(
+        availability.urllib.request, "urlopen", lambda url, timeout=4: _Resp(payload)
+    )
+
+
+def test_open_tables_exist_matches_venue_and_session(monkeypatch):
+    _patch(monkeypatch, _DATA)
+
+    assert availability.open_tables_exist(
+        ["15 Stamford Restaurant"], ["Dinner"], "http://x"
+    )
+    assert availability.open_tables_exist(["any"], ["Dinner"], "http://x")
+
+
+def test_open_tables_exist_no_match(monkeypatch):
+    _patch(monkeypatch, _DATA)
+
+    # right venue, wrong session
+    assert not availability.open_tables_exist(
+        ["15 Stamford Restaurant"], ["Lunch"], "http://x"
+    )
+    # venue with no live availability
+    assert not availability.open_tables_exist(["Cultivate"], ["Dinner"], "http://x")
+
+
+def test_open_tables_exist_fails_closed_on_error(monkeypatch):
+    def boom(url, timeout=4):
+        raise OSError("network down")
+
+    monkeypatch.setattr(availability.urllib.request, "urlopen", boom)
+
+    assert not availability.open_tables_exist(["any"], ["Dinner"], "http://x")

--- a/reminders/tests/test_db.py
+++ b/reminders/tests/test_db.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -137,6 +138,61 @@ def test_update_preferences(conn):
     record = db.get_by_unsubscribe_token(conn, token)
     assert record["party_size"] == 4
     assert record["sessions"] == ["Lunch"]
+
+
+def test_init_db_migrates_missing_dates_column(tmp_path: Path):
+    path = tmp_path / "old.db"
+    conn = db.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE subscribers (
+          id INTEGER PRIMARY KEY, email TEXT NOT NULL, name TEXT,
+          party_size INTEGER NOT NULL, sessions TEXT NOT NULL, venues TEXT NOT NULL,
+          date_start TEXT NOT NULL, date_end TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'pending', confirm_token TEXT,
+          confirm_token_expires_ts TEXT, unsubscribe_token TEXT NOT NULL,
+          source_ip TEXT, created_ts TEXT NOT NULL, confirmed_ts TEXT,
+          unsubscribed_ts TEXT
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO subscribers (email, party_size, sessions, venues, date_start, "
+        "date_end, unsubscribe_token, created_ts) VALUES "
+        "('x@e.com', 2, '[\"Dinner\"]', '[\"any\"]', '2026-07-01', '2026-07-10', "
+        "'tok', '2026-06-24T00:00:00+00:00')"
+    )
+    conn.commit()
+    conn.close()
+
+    db.init_db(path)  # must add the missing 'dates' column without losing data
+
+    conn = db.connect(path)
+    columns = {
+        row["name"]
+        for row in conn.execute("PRAGMA table_info(subscribers)").fetchall()
+    }
+    assert "dates" in columns
+    row = conn.execute("SELECT dates FROM subscribers").fetchone()
+    assert json.loads(row["dates"]) == []
+    conn.close()
+
+
+def test_specific_dates_round_trip(conn):
+    sub = SubscriberInput(
+        email="d@example.com",
+        name="Dee",
+        party_size=2,
+        sessions=["Dinner"],
+        venues=["any"],
+        date_start="2026-07-04",
+        date_end="2026-07-18",
+        dates=["2026-07-04", "2026-07-18"],
+    )
+    token = db.upsert_pending(conn, sub, ip="1.2.3.4")
+    db.confirm(conn, token)
+
+    assert db.active_subscribers(conn)[0]["dates"] == ["2026-07-04", "2026-07-18"]
 
 
 def test_event_count_window(conn):

--- a/reminders/tests/test_emailer.py
+++ b/reminders/tests/test_emailer.py
@@ -72,3 +72,12 @@ def test_confirm_email_html_contains_links():
     assert "https://svc/api/confirm?token=abc" in html
     assert "https://svc/api/unsubscribe?token=xyz" in html
     assert "Alice" in html
+    assert "Confirm my email" in html  # full body survived the good-news prepend
+
+
+def test_confirm_email_html_shows_matches_only_when_present():
+    without = emailer.confirm_email_html("Al", "c", "u", "m", matches_exist=False)
+    with_matches = emailer.confirm_email_html("Al", "c", "u", "m", matches_exist=True)
+
+    assert "Good news" not in without
+    assert "Good news" in with_matches

--- a/scripts/send_table_for_two_alerts.py
+++ b/scripts/send_table_for_two_alerts.py
@@ -653,6 +653,7 @@ def fetch_api_subscriptions(
             "party size": str(record.get("party_size") or 2),
             "date start": record.get("date_start", ""),
             "date end": record.get("date_end", ""),
+            "dates": ",".join(record.get("dates") or []),
             "sessions": ",".join(record.get("sessions") or []),
             "venues": ",".join(record.get("venues") or []),
             "unsubscribe url": record.get("unsubscribe_url", ""),

--- a/web/app.js
+++ b/web/app.js
@@ -4223,6 +4223,40 @@ function renderTableForTwoAlertSignup() {
     toInput.value = isoLocalDate(inThirtyDays);
   }
 
+  const dateAdd = document.getElementById("tft-alert-date-add");
+  const datePick = document.getElementById("tft-alert-date-pick");
+  const dateChips = document.getElementById("tft-alert-date-chips");
+  if (dateAdd && !dateAdd.dataset.wired) {
+    dateAdd.dataset.wired = "1";
+    const syncBounds = () => {
+      if (datePick && fromInput) datePick.min = fromInput.value || "";
+      if (datePick && toInput) datePick.max = toInput.value || "";
+    };
+    if (fromInput) fromInput.addEventListener("change", syncBounds);
+    if (toInput) toInput.addEventListener("change", syncBounds);
+    syncBounds();
+    dateAdd.addEventListener("click", () => {
+      const value = datePick.value;
+      if (!value) return;
+      const existing = Array.from(dateChips.querySelectorAll(".tft-date-chip")).map(
+        (chip) => chip.dataset.value,
+      );
+      if (existing.includes(value)) return;
+      const chip = document.createElement("span");
+      chip.className = "tft-date-chip";
+      chip.dataset.value = value;
+      chip.textContent = value + " ";
+      const remove = document.createElement("button");
+      remove.type = "button";
+      remove.textContent = "×";
+      remove.setAttribute("aria-label", "Remove " + value);
+      remove.addEventListener("click", () => chip.remove());
+      chip.appendChild(remove);
+      dateChips.appendChild(chip);
+      datePick.value = "";
+    });
+  }
+
   if (!tableForTwoAlertWired) {
     tableForTwoAlertWired = true;
     form.addEventListener("submit", submitTableForTwoAlert);
@@ -4261,12 +4295,16 @@ async function submitTableForTwoAlert(event) {
   const checkedVenues = Array.from(
     form.querySelectorAll(".tft-venue-cb:checked"),
   ).map((input) => input.value);
+  const specificDates = Array.from(
+    form.querySelectorAll(".tft-date-chip"),
+  ).map((chip) => chip.dataset.value);
   const payload = {
     email: form.querySelector("#tft-alert-email").value.trim(),
     name: form.querySelector("#tft-alert-name").value.trim() || null,
     party_size: Number(form.querySelector("#tft-alert-party").value || 2),
     sessions,
     venues: checkedVenues.length ? checkedVenues : ["any"],
+    dates: specificDates,
     date_start: form.querySelector("#tft-alert-from").value,
     date_end: form.querySelector("#tft-alert-to").value,
     website: form.querySelector("#tft-alert-website").value,

--- a/web/app.js
+++ b/web/app.js
@@ -4179,13 +4179,34 @@ function renderTableForTwoAlertSignup() {
   if (!tableForTwoAlertSignupPanel || !form) return;
   tableForTwoAlertSignupPanel.hidden = false;
 
-  const venueSelect = document.getElementById("tft-alert-venue");
-  if (venueSelect && venueSelect.options.length <= 1) {
+  const venueList = document.getElementById("tft-alert-venue-list");
+  const anyToggle = document.getElementById("tft-alert-any");
+  if (venueList && venueList.children.length === 0) {
     for (const name of tableForTwoAlertVenueNames()) {
-      const option = document.createElement("option");
-      option.value = name;
-      option.textContent = name;
-      venueSelect.appendChild(option);
+      const label = document.createElement("label");
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.value = name;
+      checkbox.className = "tft-venue-cb";
+      label.appendChild(checkbox);
+      label.appendChild(document.createTextNode(" " + name));
+      venueList.appendChild(label);
+    }
+    venueList.addEventListener("change", () => {
+      const anyChecked =
+        venueList.querySelectorAll(".tft-venue-cb:checked").length > 0;
+      if (anyToggle) anyToggle.checked = !anyChecked;
+    });
+    if (anyToggle) {
+      anyToggle.addEventListener("change", () => {
+        if (anyToggle.checked) {
+          venueList
+            .querySelectorAll(".tft-venue-cb:checked")
+            .forEach((checkbox) => {
+              checkbox.checked = false;
+            });
+        }
+      });
     }
   }
 
@@ -4237,12 +4258,15 @@ async function submitTableForTwoAlert(event) {
     return;
   }
 
+  const checkedVenues = Array.from(
+    form.querySelectorAll(".tft-venue-cb:checked"),
+  ).map((input) => input.value);
   const payload = {
     email: form.querySelector("#tft-alert-email").value.trim(),
     name: form.querySelector("#tft-alert-name").value.trim() || null,
     party_size: Number(form.querySelector("#tft-alert-party").value || 2),
     sessions,
-    venues: [form.querySelector("#tft-alert-venue").value],
+    venues: checkedVenues.length ? checkedVenues : ["any"],
     date_start: form.querySelector("#tft-alert-from").value,
     date_end: form.querySelector("#tft-alert-to").value,
     website: form.querySelector("#tft-alert-website").value,

--- a/web/index.html
+++ b/web/index.html
@@ -865,12 +865,11 @@
                       <span>Party size</span>
                       <input type="number" id="tft-alert-party" name="party_size" min="1" max="20" value="2" required />
                     </label>
-                    <label class="tft-field tft-field--full">
-                      <span>Venue</span>
-                      <select id="tft-alert-venue" name="venue">
-                        <option value="any">Any venue</option>
-                      </select>
-                    </label>
+                    <fieldset class="tft-field tft-field--full tft-field--venues">
+                      <span>Venues</span>
+                      <label class="tft-venue-any"><input type="checkbox" id="tft-alert-any" checked /> Any venue</label>
+                      <div class="tft-venue-list" id="tft-alert-venue-list"></div>
+                    </fieldset>
                     <fieldset class="tft-field tft-field--full tft-field--sessions">
                       <span>Session</span>
                       <div class="tft-checks">

--- a/web/index.html
+++ b/web/index.html
@@ -885,6 +885,15 @@
                       <span>To</span>
                       <input type="date" id="tft-alert-to" name="date_end" required />
                     </label>
+                    <fieldset class="tft-field tft-field--full tft-field--dates">
+                      <span>Specific dates <em>(optional)</em></span>
+                      <div class="tft-date-adder">
+                        <input type="date" id="tft-alert-date-pick" />
+                        <button type="button" class="tft-date-add" id="tft-alert-date-add">Add date</button>
+                      </div>
+                      <div class="tft-date-chips" id="tft-alert-date-chips"></div>
+                      <p class="tft-date-hint">Leave empty to get alerts for any date in your range above.</p>
+                    </fieldset>
                     <input type="text" id="tft-alert-website" name="website" class="tft-hp" tabindex="-1" autocomplete="off" aria-hidden="true" />
                   </div>
                   <button type="submit" class="tft-alert-submit" id="tft-alert-submit">Email me when a table opens</button>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1156,6 +1156,48 @@ input,
   accent-color: var(--teal);
 }
 
+.tft-field--venues .tft-venue-any {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text, #e8edf5);
+  cursor: pointer;
+  padding-top: 2px;
+}
+
+.tft-field--venues .tft-venue-any input {
+  width: auto;
+  accent-color: var(--teal);
+}
+
+.tft-venue-list {
+  display: grid;
+  gap: 6px;
+  max-height: 150px;
+  overflow-y: auto;
+  padding: 8px 10px;
+  border: 1px solid var(--surface-border-soft);
+  border-radius: 10px;
+  background: var(--bg);
+}
+
+.tft-venue-list label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text, #e8edf5);
+  cursor: pointer;
+}
+
+.tft-venue-list input {
+  width: auto;
+  flex: none;
+  accent-color: var(--teal);
+}
+
 .tft-alert-submit {
   width: 100%;
   padding: 11px 14px;

--- a/web/styles.css
+++ b/web/styles.css
@@ -1198,6 +1198,83 @@ input,
   accent-color: var(--teal);
 }
 
+.tft-field--dates {
+  gap: 8px;
+}
+
+.tft-date-adder {
+  display: flex;
+  gap: 8px;
+}
+
+.tft-date-adder input {
+  flex: 1;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 9px 10px;
+  font-family: inherit;
+  font-size: 14px;
+  color: var(--text, #e8edf5);
+  background: var(--bg);
+  border: 1px solid var(--surface-border-soft);
+  border-radius: 10px;
+}
+
+.tft-date-add {
+  flex: none;
+  padding: 0 14px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--teal);
+  background: var(--teal-surface);
+  border: 1px solid var(--teal-border);
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.tft-date-add:hover {
+  background: var(--teal-surface-strong);
+}
+
+.tft-date-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tft-date-chips:empty {
+  display: none;
+}
+
+.tft-date-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 4px 4px 9px;
+  font-size: 12px;
+  color: var(--text, #e8edf5);
+  background: var(--surface-soft);
+  border: 1px solid var(--surface-border-soft);
+  border-radius: 999px;
+}
+
+.tft-date-chip button {
+  border: none;
+  background: none;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.tft-date-hint {
+  margin: 0;
+  font-size: 11px;
+  color: var(--muted);
+}
+
 .tft-alert-submit {
   width: 100%;
   padding: 11px 14px;


### PR DESCRIPTION
Three subscriber-facing improvements (multi-venue is frontend-only; the others touch the service).

## Multi-venue selection
- Single venue dropdown → 'Any venue' toggle + scrollable checklist on the signup form and the manage page. Submit sends the list (backend already accepted it).

## Optional specific dates
- Add specific dates alongside the range (form + manage page). When set, the matcher restricts alerts to those exact dates within the range.
- Backend: `dates` on the schema + a JSON column with a safe ALTER-TABLE **migration** for the live DB; export + alert-job passthrough. Migration verified live (no data loss).

## Confirm email flags existing matches
- On signup, a coarse venue+session availability check against the live data; when the picked venues already have open tables, the confirm email leads with a 'Good news' note. Fails closed if the data is unreachable; no matcher duplication. Double opt-in unchanged.

40 tests passing. The reminders service is already deployed with these changes; merging this publishes the new **form** to the live site (Deploy Pages).