### PR TITLE
feat(seo): homepage metadata + robots/sitemap/llms (corrected)

### DIFF
--- a/web/.well-known/security.txt
+++ b/web/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:haomingkoo@gmail.com
+Preferred-Languages: en
+Canonical: https://amex-explorer.kooexperience.com/.well-known/security.txt
+Expires: 2027-05-08T00:00:00Z

--- a/web/index.html
+++ b/web/index.html
@@ -5,10 +5,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="color-scheme" content="dark light" />
     <meta name="theme-color" content="#070d16" />
-    <title>Unofficial Platinum Experience</title>
+    <title>Amex Platinum Benefits Explorer Singapore | Dining, Hotels, Table for Two</title>
     <meta
       name="description"
-      content="Unofficial Platinum Experience — explore Amex Platinum dining, hotels, and partner benefits."
+      content="Map-first unofficial explorer for Singapore-issued American Express Platinum benefits, including Global Dining Credit, Local Dining Credit, Love Dining, Table for Two, and Plat Stay hotel partners."
+    />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="https://amex-explorer.kooexperience.com/" />
+    <link rel="sitemap" type="application/xml" href="https://amex-explorer.kooexperience.com/sitemap.xml" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Unofficial Platinum Experience" />
+    <meta property="og:title" content="Amex Platinum Benefits Explorer Singapore" />
+    <meta
+      property="og:description"
+      content="Source-backed map explorer for Singapore Amex Platinum dining, hotel, and set-menu benefits."
+    />
+    <meta property="og:url" content="https://amex-explorer.kooexperience.com/" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Amex Platinum Benefits Explorer Singapore" />
+    <meta
+      name="twitter:description"
+      content="Explore Amex Platinum dining credits, Love Dining, Table for Two, and Plat Stay partners in one unofficial map."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -25,6 +42,32 @@
       href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css"
     />
     <link rel="stylesheet" href="./styles.css?v=dev" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "Unofficial Platinum Experience",
+        "alternateName": "Amex Platinum Benefits Explorer Singapore",
+        "url": "https://amex-explorer.kooexperience.com/",
+        "applicationCategory": "TravelApplication",
+        "operatingSystem": "Web",
+        "description": "Unofficial source-backed explorer for Singapore-issued American Express Platinum dining, hotel, and set-menu benefits.",
+        "inLanguage": "en-SG",
+        "isAccessibleForFree": true,
+        "creator": {
+          "@type": "Person",
+          "name": "Haoming Koo",
+          "url": "https://kooexperience.com/"
+        },
+        "about": [
+          "American Express Platinum Singapore",
+          "Global Dining Credit",
+          "Love Dining Singapore",
+          "Table for Two Singapore",
+          "Plat Stay"
+        ]
+      }
+    </script>
   </head>
   <body>
 

--- a/web/llms.txt
+++ b/web/llms.txt
@@ -1,0 +1,23 @@
+# Unofficial Platinum Experience
+
+> Source-backed map explorer for Singapore-issued American Express Platinum benefits.
+
+The site helps users explore and compare dining, hotel, and set-menu benefits for Singapore-issued American Express Platinum cards. It is an unofficial planning tool and links back to official American Express, Pocket Concierge, and partner sources for final eligibility checks.
+
+## Important Pages
+
+- [Amex Platinum Benefits Explorer](https://amex-explorer.kooexperience.com/) — the full map app. A single-page app whose sections (Global Dining Credit, Singapore Local Dining Credit, Japan Pocket Concierge dining, Plat Stay hotels, Love Dining, and Table for Two with availability reminders) all load from this page.
+
+## Data Files
+
+- [Global dining records](https://amex-explorer.kooexperience.com/data/global-restaurants.json)
+- [Japan dining records](https://amex-explorer.kooexperience.com/data/japan-restaurants.json)
+- [Plat Stay records](https://amex-explorer.kooexperience.com/data/plat-stays.json)
+- [Love Dining records](https://amex-explorer.kooexperience.com/data/love-dining.json)
+- [Table for Two records](https://amex-explorer.kooexperience.com/data/table-for-two.json)
+
+## Notes
+
+- This is not an official American Express website.
+- Cached data can become stale; users should confirm final terms, eligibility, blackout dates, and availability with American Express and the participating venue.
+- Table for Two bookings and voucher redemption happen in the Amex Experiences App.

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://amex-explorer.kooexperience.com/sitemap.xml

--- a/web/security.txt
+++ b/web/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:haomingkoo@gmail.com
+Preferred-Languages: en
+Canonical: https://amex-explorer.kooexperience.com/.well-known/security.txt
+Expires: 2027-05-08T00:00:00Z

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://amex-explorer.kooexperience.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Replaces the stale PR #29 (which predated the reminders work and had a sitemap of 404s).

- Homepage SEO title/description, canonical, OpenGraph/Twitter, WebApplication JSON-LD
- robots.txt + **corrected sitemap** — only the real `/` homepage. The path-style landing pages (/dining/, /table-for-two/, etc.) in the original sitemap were never built and 404; the SPA hash routes aren't separately crawlable.
- llms.txt trimmed to live URLs (homepage + the 5 working /data/*.json)
- security.txt (contact: haomingkoo@gmail.com)
- Excludes the orphan seo.css (linked nowhere)

Closes #29.