### PR TITLE
feat(reminders): collapse booking-alert signup into a disclosure panel

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -889,11 +889,12 @@
                 </div>
               </div>
 
-              <div class="tft-alert-panel" id="tft-alert-signup-panel">
-                <div class="tft-alert-intro">
+              <details class="tft-alert-panel" id="tft-alert-signup-panel">
+                <summary class="tft-alert-summary">
                   <h3>Get a booking alert</h3>
-                  <p>We'll email you the moment a Table for Two slot matches your dates — only when there's real availability.</p>
-                </div>
+                  <span class="tft-alert-chevron" aria-hidden="true">▾</span>
+                </summary>
+                <p class="tft-alert-lead">We'll email you the moment a Table for Two slot matches your dates — only when there's real availability.</p>
                 <form class="tft-alert-form" id="tft-alert-form" novalidate>
                   <div class="tft-alert-form__grid">
                     <label class="tft-field tft-field--full">

--- a/web/styles.css
+++ b/web/styles.css
@@ -1049,9 +1049,7 @@ input,
 }
 
 .tft-alert-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  display: block;
   margin: 0 16px 12px;
   padding: 14px;
   border: 1px solid var(--surface-border-soft);
@@ -1059,19 +1057,44 @@ input,
   background: var(--surface-soft);
 }
 
+.tft-alert-form {
+  margin-top: 12px;
+}
+
 .tft-alert-panel[hidden] {
   display: none;
 }
 
-.tft-alert-panel h3 {
-  margin: 0 0 4px;
-  font-size: 15px;
-  font-weight: 650;
-  letter-spacing: 0;
+.tft-alert-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  list-style: none;
 }
 
-.tft-alert-panel p {
+.tft-alert-summary::-webkit-details-marker {
+  display: none;
+}
+
+.tft-alert-summary h3 {
   margin: 0;
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.tft-alert-chevron {
+  color: var(--muted);
+  font-size: 13px;
+  transition: transform 0.15s ease;
+}
+
+.tft-alert-panel[open] .tft-alert-chevron {
+  transform: rotate(180deg);
+}
+
+.tft-alert-lead {
+  margin: 12px 0 0;
   color: var(--muted);
   font-size: 13px;
   line-height: 1.35;


### PR DESCRIPTION
Swap the always-open Table for Two alert `<div>` for a native `<details>`/`<summary>` so it starts collapsed and expands on click — no JS.

- Custom chevron rotates on open; native marker hidden cross-browser (Safari + Firefox/Chrome).
- Verified in-browser at mobile width: 55px collapsed → 633px open → 55px on re-close.

Excludes the unrelated orphan `web/seo.css`.