### PR TITLE
fix: keep TFT menu review state across roster refreshes

### DIFF
--- a/data/table-for-two.json
+++ b/data/table-for-two.json
@@ -131099,5 +131099,642 @@
         "changed_at": null
       }
     }
-  ]
+  ],
+  "menu_source": {
+    "aem_listing_urls": {
+      "platinum": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining.1.json",
+      "centurion": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle.1.json"
+    },
+    "checked_at": "2026-09-02T22:48:18Z",
+    "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+    "pdfs_in_listing": 45,
+    "menus_matched": 35,
+    "venues_matched": 20,
+    "venues_buffet": 4,
+    "venues_review": 6,
+    "unmatched_pdfs": [
+      "JAG-Sample-Menu_Centurion.pdf",
+      "Lerouy-Sample-Menu_Centurion.pdf",
+      "Osteria-Mozza-Menu-Platinum.pdf",
+      "Pradacaffe-Menu.pdf",
+      "Shisen-Hanten-Menu_Centurion.pdf",
+      "Summer-Pavillion-Menu_Centurion.pdf",
+      "The-Courtyard-Menu_Centurion.pdf",
+      "VUE-Menu_Platinium.pdf",
+      "Vivino-Menu_Centurion.pdf",
+      "Vivino-Menu_Platinum.pdf"
+    ],
+    "unmatched_assets": [
+      {
+        "card": "centurion",
+        "filename": "JAG-Sample-Menu_Centurion.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/JAG-Sample-Menu_Centurion.pdf",
+        "aem_created": "Wed Jul 08 2026 01:32:30 GMT-0700",
+        "aem_uuid": "9f58396c-11d4-4711-98e7-d02836d2612e",
+        "classification": "not_in_reviewed_roster",
+        "candidate_venue_id": null,
+        "candidate_venue_ids": [],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:48:18Z"
+      },
+      {
+        "card": "centurion",
+        "filename": "Lerouy-Sample-Menu_Centurion.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Lerouy-Sample-Menu_Centurion.pdf",
+        "aem_created": "Wed Apr 29 2026 22:40:26 GMT-0700",
+        "aem_uuid": "87ddd297-2c2a-4954-8af7-2d96dc1ddf6a",
+        "classification": "not_in_reviewed_roster",
+        "candidate_venue_id": null,
+        "candidate_venue_ids": [],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:48:18Z"
+      },
+      {
+        "card": "centurion",
+        "filename": "Pradacaffe-Menu.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Pradacaffe-Menu.pdf",
+        "aem_created": "Tue Jun 30 2026 02:54:44 GMT-0700",
+        "aem_uuid": "e6c6b759-c41a-42a0-ac7c-e38550dbe41f",
+        "classification": "not_in_reviewed_roster",
+        "candidate_venue_id": null,
+        "candidate_venue_ids": [],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:48:18Z"
+      },
+      {
+        "card": "centurion",
+        "filename": "Shisen-Hanten-Menu_Centurion.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Shisen-Hanten-Menu_Centurion.pdf",
+        "aem_created": "Thu Apr 30 2026 00:39:22 GMT-0700",
+        "aem_uuid": "8097c8f4-80c5-446d-ada9-5ea68c99b94b",
+        "classification": "not_in_reviewed_roster",
+        "candidate_venue_id": null,
+        "candidate_venue_ids": [],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:48:18Z"
+      },
+      {
+        "card": "centurion",
+        "filename": "Summer-Pavillion-Menu_Centurion.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Summer-Pavillion-Menu_Centurion.pdf",
+        "aem_created": "Thu Apr 30 2026 00:40:23 GMT-0700",
+        "aem_uuid": "60e2dbc7-29bc-4866-a2d3-d8deea4c5df1",
+        "classification": "not_in_reviewed_roster",
+        "candidate_venue_id": null,
+        "candidate_venue_ids": [],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:48:18Z"
+      },
+      {
+        "card": "centurion",
+        "filename": "The-Courtyard-Menu_Centurion.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/The-Courtyard-Menu_Centurion.pdf",
+        "aem_created": "Thu Apr 30 2026 00:39:07 GMT-0700",
+        "aem_uuid": "4ae4a2ae-9333-494f-8ee3-77736dcc7e88",
+        "classification": "not_in_reviewed_roster",
+        "candidate_venue_id": null,
+        "candidate_venue_ids": [],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:48:18Z"
+      },
+      {
+        "card": "centurion",
+        "filename": "Vivino-Menu_Centurion.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Vivino-Menu_Centurion.pdf",
+        "aem_created": "Thu Jul 02 2026 01:38:14 GMT-0700",
+        "aem_uuid": "5894b15a-af26-4325-9346-400ad5b9777e",
+        "classification": "not_in_reviewed_roster",
+        "candidate_venue_id": null,
+        "candidate_venue_ids": [],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:48:18Z"
+      },
+      {
+        "card": "platinum",
+        "filename": "Osteria-Mozza-Menu-Platinum.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Osteria-Mozza-Menu-Platinum.pdf",
+        "aem_created": "Sun Jul 12 2026 21:01:07 GMT-0700",
+        "aem_uuid": "6b6edfaf-7ad6-4f09-98fb-fef11972b7ca",
+        "classification": "current_venue_duplicate",
+        "candidate_venue_id": "tft-osteria-mozza",
+        "candidate_venue_ids": [
+          "tft-osteria-mozza"
+        ],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:48:18Z",
+        "sha256": "b16c06e20ba481fd33109c8372769b3fb25ff828eca992f9fe982afbe6eb18ad",
+        "bytes": 1526738,
+        "active_filename": "Osteria-Mozza-Menu_Platinum.pdf",
+        "active_sha256": "3347607d410858391fc27cd26bed019c981fdca45b1fe50f8666a5d08eeb22d9",
+        "previous": {
+          "status": "published",
+          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Osteria-Mozza-Menu_Platinum.pdf",
+          "filename": "Osteria-Mozza-Menu_Platinum.pdf",
+          "card": "platinum",
+          "label": "Platinum",
+          "checked_at": "2026-09-02T22:48:18Z",
+          "first_seen_at": "2026-07-18T02:12:29Z",
+          "last_seen_at": "2026-09-02T22:48:18Z",
+          "sha256": "3347607d410858391fc27cd26bed019c981fdca45b1fe50f8666a5d08eeb22d9",
+          "bytes": 109793,
+          "aem_created": "Thu Feb 05 2026 00:36:18 GMT-0700",
+          "changed_at": null
+        },
+        "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+        "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e"
+      },
+      {
+        "card": "platinum",
+        "filename": "VUE-Menu_Platinium.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/VUE-Menu_Platinium.pdf",
+        "aem_created": "Tue Jun 30 2026 02:39:26 GMT-0700",
+        "aem_uuid": "a0a7bbf3-2d55-4fb6-9c9c-0965dbab4e2b",
+        "classification": "current_venue_duplicate",
+        "candidate_venue_id": "tft-vue",
+        "candidate_venue_ids": [
+          "tft-vue"
+        ],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:48:18Z",
+        "sha256": "559b3b04c699f5d725a2dbd96aed19cad522c1c1318bdbe511bd6e054c1ee18f",
+        "bytes": 169039,
+        "active_filename": "VUE-Menu_Platinum.pdf",
+        "active_sha256": "af9a1807f718b52711a8dbf27388e5f3a0c5e4a1a108d432c21ca36112b1b868",
+        "previous": {
+          "status": "published",
+          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/VUE-Menu_Platinum.pdf",
+          "filename": "VUE-Menu_Platinum.pdf",
+          "card": "platinum",
+          "label": "Platinum",
+          "checked_at": "2026-09-02T22:48:18Z",
+          "first_seen_at": "2026-07-18T02:12:29Z",
+          "last_seen_at": "2026-09-02T22:48:18Z",
+          "sha256": "af9a1807f718b52711a8dbf27388e5f3a0c5e4a1a108d432c21ca36112b1b868",
+          "bytes": 1060252,
+          "aem_created": "Thu Apr 30 2026 00:37:23 GMT-0700",
+          "changed_at": null
+        },
+        "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+        "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e"
+      },
+      {
+        "card": "platinum",
+        "filename": "Vivino-Menu_Platinum.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Vivino-Menu_Platinum.pdf",
+        "aem_created": "Thu Jul 02 2026 01:09:23 GMT-0700",
+        "aem_uuid": "d9b1cf82-d6fa-4051-8a86-f4997fcac54f",
+        "classification": "not_in_reviewed_roster",
+        "candidate_venue_id": null,
+        "candidate_venue_ids": [],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:48:18Z"
+      }
+    ],
+    "review_queue": [
+      {
+        "status": "review_required",
+        "kind": "missing_venue_menu",
+        "venue_id": "tft-one-ninety",
+        "venue_name": "One-Ninety",
+        "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+        "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+        "detected_at": "2026-09-02T22:00:42Z",
+        "first_detected_at": "2026-09-02T22:00:42Z",
+        "candidate_id": "a8177bc66c7bdc4e115faa49df6efd211bf32f41bd2eaa37c834d914ddccf68e"
+      },
+      {
+        "status": "review_required",
+        "kind": "missing_venue_menu",
+        "venue_id": "tft-grand-cru-wine-bar",
+        "venue_name": "Grand Cru Wine Bar",
+        "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+        "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+        "detected_at": "2026-09-02T22:00:42Z",
+        "first_detected_at": "2026-09-02T22:00:42Z",
+        "candidate_id": "82030cbdb46d334e8968634c34aed180c12a1d04f9d57bf27865882ab2fcfb23"
+      },
+      {
+        "status": "review_required",
+        "kind": "missing_venue_menu",
+        "venue_id": "tft-brewerkz-east-coast-park",
+        "venue_name": "Brewerkz East Coast Park",
+        "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+        "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+        "detected_at": "2026-09-02T22:00:42Z",
+        "first_detected_at": "2026-09-02T22:00:42Z",
+        "candidate_id": "766f1e65ed1f28a69a73dce32da63332a1a542432d562085d2efc35e100d0e08"
+      },
+      {
+        "status": "review_required",
+        "kind": "missing_venue_menu",
+        "venue_id": "tft-brewerkz-riverside-point",
+        "venue_name": "Brewerkz Riverside Point",
+        "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+        "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+        "detected_at": "2026-09-02T22:00:42Z",
+        "first_detected_at": "2026-09-02T22:00:42Z",
+        "candidate_id": "fbbbd1adf8fc12cefd8b401c9e1f38c6e0fde1ee28db220a7c5f61b7b88a8ab7"
+      },
+      {
+        "status": "review_required",
+        "kind": "missing_venue_menu",
+        "venue_id": "tft-park90",
+        "venue_name": "Park90",
+        "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+        "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+        "detected_at": "2026-09-02T22:48:18Z",
+        "first_detected_at": "2026-09-02T22:48:18Z",
+        "candidate_id": "f7bfa47405eb3b8276a04a6cbb8d99460e5614892a78e2bc983b38358964d1f4"
+      },
+      {
+        "status": "review_required",
+        "kind": "missing_venue_menu",
+        "venue_id": "tft-oso-ristorante",
+        "venue_name": "OSO Ristorante",
+        "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+        "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+        "detected_at": "2026-09-02T22:00:42Z",
+        "first_detected_at": "2026-09-02T22:00:42Z",
+        "candidate_id": "1510f5312deaf9ce75974956609d7d6094425daa43ebc6d514a6cb1c23ee6bfd"
+      },
+      {
+        "status": "review_required",
+        "kind": "ambiguous_exact_match",
+        "card": "platinum",
+        "filename": "Osteria-Mozza-Menu-Platinum.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Osteria-Mozza-Menu-Platinum.pdf",
+        "aem_created": "Sun Jul 12 2026 21:01:07 GMT-0700",
+        "aem_uuid": "6b6edfaf-7ad6-4f09-98fb-fef11972b7ca",
+        "classification": "current_venue_duplicate",
+        "candidate_venue_id": "tft-osteria-mozza",
+        "candidate_venue_ids": [
+          "tft-osteria-mozza"
+        ],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:00:42Z",
+        "sha256": "b16c06e20ba481fd33109c8372769b3fb25ff828eca992f9fe982afbe6eb18ad",
+        "bytes": 1526738,
+        "active_filename": "Osteria-Mozza-Menu_Platinum.pdf",
+        "active_sha256": "3347607d410858391fc27cd26bed019c981fdca45b1fe50f8666a5d08eeb22d9",
+        "previous": {
+          "status": "published",
+          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Osteria-Mozza-Menu_Platinum.pdf",
+          "filename": "Osteria-Mozza-Menu_Platinum.pdf",
+          "card": "platinum",
+          "label": "Platinum",
+          "checked_at": "2026-09-02T22:48:18Z",
+          "first_seen_at": "2026-07-18T02:12:29Z",
+          "last_seen_at": "2026-09-02T22:48:18Z",
+          "sha256": "3347607d410858391fc27cd26bed019c981fdca45b1fe50f8666a5d08eeb22d9",
+          "bytes": 109793,
+          "aem_created": "Thu Feb 05 2026 00:36:18 GMT-0700",
+          "changed_at": null
+        },
+        "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+        "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+        "first_detected_at": "2026-09-02T22:00:42Z",
+        "candidate_id": "be88f2f2037ae778c887384c02f4dfbca6b6d0685fafbfd09fc044027a95cc8d"
+      },
+      {
+        "status": "review_required",
+        "kind": "ambiguous_exact_match",
+        "card": "platinum",
+        "filename": "VUE-Menu_Platinium.pdf",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/VUE-Menu_Platinium.pdf",
+        "aem_created": "Tue Jun 30 2026 02:39:26 GMT-0700",
+        "aem_uuid": "a0a7bbf3-2d55-4fb6-9c9c-0965dbab4e2b",
+        "classification": "current_venue_duplicate",
+        "candidate_venue_id": "tft-vue",
+        "candidate_venue_ids": [
+          "tft-vue"
+        ],
+        "review_status": "review_required",
+        "detected_at": "2026-09-02T22:00:42Z",
+        "sha256": "559b3b04c699f5d725a2dbd96aed19cad522c1c1318bdbe511bd6e054c1ee18f",
+        "bytes": 169039,
+        "active_filename": "VUE-Menu_Platinum.pdf",
+        "active_sha256": "af9a1807f718b52711a8dbf27388e5f3a0c5e4a1a108d432c21ca36112b1b868",
+        "previous": {
+          "status": "published",
+          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/VUE-Menu_Platinum.pdf",
+          "filename": "VUE-Menu_Platinum.pdf",
+          "card": "platinum",
+          "label": "Platinum",
+          "checked_at": "2026-09-02T22:48:18Z",
+          "first_seen_at": "2026-07-18T02:12:29Z",
+          "last_seen_at": "2026-09-02T22:48:18Z",
+          "sha256": "af9a1807f718b52711a8dbf27388e5f3a0c5e4a1a108d432c21ca36112b1b868",
+          "bytes": 1060252,
+          "aem_created": "Thu Apr 30 2026 00:37:23 GMT-0700",
+          "changed_at": null
+        },
+        "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+        "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+        "first_detected_at": "2026-09-02T22:00:42Z",
+        "candidate_id": "a7196b1c998ef060a57b0f7aaf7aae87346f5591bda13d3645d196dc7e635bfe"
+      }
+    ],
+    "review_queue_count": 8,
+    "review_queue_sha256": "12919b6268935a136430bfee7ccef06a3d43224a21c41e48826c6cd74ad395fc",
+    "review_required": true,
+    "review_decisions": [
+      {
+        "candidate_id": "a55e035a98246946f5d75546f2eddc45b2ff898b07080f3996d06af140de5f83",
+        "decision": "approved",
+        "manifest_sha256": "f3e896af25bda6a1897204d51b4401d28844276cf815d844aef9a77c25c876e9",
+        "reviewed_at": "2026-09-02T22:01:31Z",
+        "reviewed_by": "repository-maintainer",
+        "review_note": "Verified exact Amex-hosted PDF text identifies Forage as a Table for Two by Platinum menu.",
+        "candidate": {
+          "kind": "changed_or_new_venue_menu",
+          "venue_id": "tft-forage",
+          "card": "platinum",
+          "filename": "Forage-Menu_Platinium.pdf",
+          "source_url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Forage-Menu_Platinium.pdf",
+          "asset_sha256": "72c0b83a7423c846dfca177ed203329ac81ae211979ca37557885be8090ed62d",
+          "bytes": 238248,
+          "aem_uuid": "b64852d5-fe3b-4d87-bba6-0eda4099b74c",
+          "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+          "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+          "previous": null
+        },
+        "candidate_item": {
+          "status": "review_required",
+          "kind": "changed_or_new_venue_menu",
+          "venue_id": "tft-forage",
+          "venue_name": "Forage",
+          "card": "platinum",
+          "filename": "Forage-Menu_Platinium.pdf",
+          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Forage-Menu_Platinium.pdf",
+          "sha256": "72c0b83a7423c846dfca177ed203329ac81ae211979ca37557885be8090ed62d",
+          "bytes": 238248,
+          "aem_uuid": "b64852d5-fe3b-4d87-bba6-0eda4099b74c",
+          "previous_sha256": null,
+          "previous": null,
+          "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+          "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+          "detected_at": "2026-09-02T22:00:42Z",
+          "first_detected_at": "2026-09-02T22:00:42Z",
+          "candidate_id": "a55e035a98246946f5d75546f2eddc45b2ff898b07080f3996d06af140de5f83"
+        },
+        "manifest": {
+          "schema_version": 1,
+          "program_id": "table-for-two",
+          "review_queue_sha256": "01d2fad2cd9f69746c7323174030e375d8ef67d7bc24b7e5bc57cf6586a5b53e",
+          "candidate_id": "a55e035a98246946f5d75546f2eddc45b2ff898b07080f3996d06af140de5f83",
+          "decision": "approved",
+          "kind": "changed_or_new_venue_menu",
+          "venue_id": "tft-forage",
+          "card": "platinum",
+          "filename": "Forage-Menu_Platinium.pdf",
+          "source_url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Forage-Menu_Platinium.pdf",
+          "asset_sha256": "72c0b83a7423c846dfca177ed203329ac81ae211979ca37557885be8090ed62d",
+          "bytes": 238248,
+          "aem_uuid": "b64852d5-fe3b-4d87-bba6-0eda4099b74c",
+          "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+          "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+          "reviewed_at": "2026-09-02T22:01:31Z",
+          "reviewed_by": "repository-maintainer",
+          "review_note": "Verified exact Amex-hosted PDF text identifies Forage as a Table for Two by Platinum menu."
+        },
+        "owner_event": {
+          "program": "Table for Two",
+          "program_id": "table-for-two",
+          "route": "#/table-for-two?venue=tft-forage",
+          "kind": "menu_added",
+          "subject": "Forage · Platinum menu",
+          "detected_at": "2026-09-02T22:00:42Z",
+          "status": "published",
+          "before": {
+            "state": "not_published",
+            "fields": {
+              "Menu file": "Not published",
+              "Menu version": "Not published"
+            }
+          },
+          "after": {
+            "state": "published",
+            "fields": {
+              "Menu file": "Forage-Menu_Platinium.pdf",
+              "Menu version": "72c0b83a7423"
+            }
+          },
+          "changes": [
+            {
+              "field": "Menu file",
+              "before": "Not published",
+              "after": "Forage-Menu_Platinium.pdf"
+            },
+            {
+              "field": "Menu version",
+              "before": "Not published",
+              "after": "72c0b83a7423"
+            }
+          ],
+          "source_url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Forage-Menu_Platinium.pdf",
+          "reviewed_at": "2026-09-02T22:01:31Z",
+          "review_note": "Verified exact Amex-hosted PDF text identifies Forage as a Table for Two by Platinum menu.",
+          "entity_key": "record:tft-forage:menu:platinum"
+        }
+      },
+      {
+        "candidate_id": "11474079c9464ef2a8207d3d96b57ba93a03dd57f5e878ee6b8879f2791f4f0c",
+        "decision": "approved",
+        "manifest_sha256": "0017058c0dfb0baf2f7293628e87e6ddc0e4b52e101d33371ed0cfe868ff2607",
+        "reviewed_at": "2026-09-02T22:01:32Z",
+        "reviewed_by": "repository-maintainer",
+        "review_note": "Verified exact Amex-hosted PDF text identifies Sarnies as an American Express Table for Two menu.",
+        "candidate": {
+          "kind": "changed_or_new_venue_menu",
+          "venue_id": "tft-sarnies",
+          "card": "platinum",
+          "filename": "Sarnies-Menu.pdf",
+          "source_url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Sarnies-Menu.pdf",
+          "asset_sha256": "3c1a4122d5d589755dce2fb4aaa677385edf65ccc0cc412681023a811ce03f95",
+          "bytes": 3298511,
+          "aem_uuid": "ecb8104f-3fb0-4d0a-8f10-bc8050583281",
+          "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+          "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+          "previous": null
+        },
+        "candidate_item": {
+          "status": "review_required",
+          "kind": "changed_or_new_venue_menu",
+          "venue_id": "tft-sarnies",
+          "venue_name": "Sarnies",
+          "card": "platinum",
+          "filename": "Sarnies-Menu.pdf",
+          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Sarnies-Menu.pdf",
+          "sha256": "3c1a4122d5d589755dce2fb4aaa677385edf65ccc0cc412681023a811ce03f95",
+          "bytes": 3298511,
+          "aem_uuid": "ecb8104f-3fb0-4d0a-8f10-bc8050583281",
+          "previous_sha256": null,
+          "previous": null,
+          "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+          "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+          "detected_at": "2026-09-02T22:00:42Z",
+          "first_detected_at": "2026-09-02T22:00:42Z",
+          "candidate_id": "11474079c9464ef2a8207d3d96b57ba93a03dd57f5e878ee6b8879f2791f4f0c"
+        },
+        "manifest": {
+          "schema_version": 1,
+          "program_id": "table-for-two",
+          "review_queue_sha256": "54ccf1eca51c646baf19aba11e04942bdd8eedf272e521d1cdca09ceca69224b",
+          "candidate_id": "11474079c9464ef2a8207d3d96b57ba93a03dd57f5e878ee6b8879f2791f4f0c",
+          "decision": "approved",
+          "kind": "changed_or_new_venue_menu",
+          "venue_id": "tft-sarnies",
+          "card": "platinum",
+          "filename": "Sarnies-Menu.pdf",
+          "source_url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Sarnies-Menu.pdf",
+          "asset_sha256": "3c1a4122d5d589755dce2fb4aaa677385edf65ccc0cc412681023a811ce03f95",
+          "bytes": 3298511,
+          "aem_uuid": "ecb8104f-3fb0-4d0a-8f10-bc8050583281",
+          "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+          "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+          "reviewed_at": "2026-09-02T22:01:32Z",
+          "reviewed_by": "repository-maintainer",
+          "review_note": "Verified exact Amex-hosted PDF text identifies Sarnies as an American Express Table for Two menu."
+        },
+        "owner_event": {
+          "program": "Table for Two",
+          "program_id": "table-for-two",
+          "route": "#/table-for-two?venue=tft-sarnies",
+          "kind": "menu_added",
+          "subject": "Sarnies · Platinum menu",
+          "detected_at": "2026-09-02T22:00:42Z",
+          "status": "published",
+          "before": {
+            "state": "not_published",
+            "fields": {
+              "Menu file": "Not published",
+              "Menu version": "Not published"
+            }
+          },
+          "after": {
+            "state": "published",
+            "fields": {
+              "Menu file": "Sarnies-Menu.pdf",
+              "Menu version": "3c1a4122d5d5"
+            }
+          },
+          "changes": [
+            {
+              "field": "Menu file",
+              "before": "Not published",
+              "after": "Sarnies-Menu.pdf"
+            },
+            {
+              "field": "Menu version",
+              "before": "Not published",
+              "after": "3c1a4122d5d5"
+            }
+          ],
+          "source_url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Sarnies-Menu.pdf",
+          "reviewed_at": "2026-09-02T22:01:32Z",
+          "review_note": "Verified exact Amex-hosted PDF text identifies Sarnies as an American Express Table for Two menu.",
+          "entity_key": "record:tft-sarnies:menu:platinum"
+        }
+      },
+      {
+        "candidate_id": "238f2e0f5668e48e65ca3a3be1c8ea5b0d27dfb4353e71fb01549a2886dc45d6",
+        "decision": "approved",
+        "manifest_sha256": "d6e0c7788289ba2a74e4349e5ffc78e16b4ae3550df4916aca174692dc337da1",
+        "reviewed_at": "2026-09-02T22:15:00Z",
+        "reviewed_by": "repository-maintainer",
+        "review_note": "Verified exact Amex-hosted PDF text identifies Forage as a Table for Two by Centurion menu.",
+        "candidate": {
+          "kind": "changed_or_new_venue_menu",
+          "venue_id": "tft-forage",
+          "card": "centurion",
+          "filename": "Forage-Menu_Centurion.pdf",
+          "source_url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Forage-Menu_Centurion.pdf",
+          "asset_sha256": "cf8f3c26ca57769df8e9b845d76afe7cec261f23625b77930f4aced51b9fc127",
+          "bytes": 142849,
+          "aem_uuid": "718c7c8d-f7c2-4af7-bde7-c0c13a88a2d6",
+          "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+          "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+          "previous": null
+        },
+        "candidate_item": {
+          "status": "review_required",
+          "kind": "changed_or_new_venue_menu",
+          "venue_id": "tft-forage",
+          "venue_name": "Forage",
+          "card": "centurion",
+          "filename": "Forage-Menu_Centurion.pdf",
+          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Forage-Menu_Centurion.pdf",
+          "sha256": "cf8f3c26ca57769df8e9b845d76afe7cec261f23625b77930f4aced51b9fc127",
+          "bytes": 142849,
+          "aem_uuid": "718c7c8d-f7c2-4af7-bde7-c0c13a88a2d6",
+          "previous_sha256": null,
+          "previous": null,
+          "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+          "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+          "detected_at": "2026-09-02T22:00:42Z",
+          "first_detected_at": "2026-09-02T22:00:42Z",
+          "candidate_id": "238f2e0f5668e48e65ca3a3be1c8ea5b0d27dfb4353e71fb01549a2886dc45d6"
+        },
+        "manifest": {
+          "schema_version": 1,
+          "program_id": "table-for-two",
+          "review_queue_sha256": "130f30fe3285c80cbe42ef0453684c73b8f433be59cfe591855f276bfc779b90",
+          "candidate_id": "238f2e0f5668e48e65ca3a3be1c8ea5b0d27dfb4353e71fb01549a2886dc45d6",
+          "decision": "approved",
+          "kind": "changed_or_new_venue_menu",
+          "venue_id": "tft-forage",
+          "card": "centurion",
+          "filename": "Forage-Menu_Centurion.pdf",
+          "source_url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Forage-Menu_Centurion.pdf",
+          "asset_sha256": "cf8f3c26ca57769df8e9b845d76afe7cec261f23625b77930f4aced51b9fc127",
+          "bytes": 142849,
+          "aem_uuid": "718c7c8d-f7c2-4af7-bde7-c0c13a88a2d6",
+          "roster_sha256": "5a2c3eb79ad86ee737b8aa125bcdfffa3195954ccfcfd4ced5d86aa649398ec5",
+          "listing_sha256": "be70d8b764511d41ecce8ce09c211fc87a3988a09fee57dac1fc4e730a66513e",
+          "reviewed_at": "2026-09-02T22:15:00Z",
+          "reviewed_by": "repository-maintainer",
+          "review_note": "Verified exact Amex-hosted PDF text identifies Forage as a Table for Two by Centurion menu."
+        },
+        "owner_event": {
+          "program": "Table for Two",
+          "program_id": "table-for-two",
+          "route": "#/table-for-two?venue=tft-forage",
+          "kind": "menu_added",
+          "subject": "Forage · Centurion menu",
+          "detected_at": "2026-09-02T22:00:42Z",
+          "status": "published",
+          "before": {
+            "state": "not_published",
+            "fields": {
+              "Menu file": "Not published",
+              "Menu version": "Not published"
+            }
+          },
+          "after": {
+            "state": "published",
+            "fields": {
+              "Menu file": "Forage-Menu_Centurion.pdf",
+              "Menu version": "cf8f3c26ca57"
+            }
+          },
+          "changes": [
+            {
+              "field": "Menu file",
+              "before": "Not published",
+              "after": "Forage-Menu_Centurion.pdf"
+            },
+            {
+              "field": "Menu version",
+              "before": "Not published",
+              "after": "cf8f3c26ca57"
+            }
+          ],
+          "source_url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Forage-Menu_Centurion.pdf",
+          "reviewed_at": "2026-09-02T22:15:00Z",
+          "review_note": "Verified exact Amex-hosted PDF text identifies Forage as a Table for Two by Centurion menu.",
+          "entity_key": "record:tft-forage:menu:centurion"
+        }
+      }
+    ]
+  }
 }

--- a/reminders/app/tft_guide_catalog.json
+++ b/reminders/app/tft_guide_catalog.json
@@ -3,7 +3,7 @@
   "source": "data/table-for-two.json",
   "program": "American Express Table for Two by Platinum",
   "official_url": "https://www.americanexpress.com/en-sg/benefits/the-platinum-card/dining/table-for-two/",
-  "roster_checked_at": "2026-09-02T21:58:08Z",
+  "roster_checked_at": "2026-09-02T23:47:00Z",
   "menu_source": {
     "checked_at": "2026-09-02T22:48:18Z",
     "review_required": true,
@@ -12,7 +12,7 @@
   "release_source": {
     "source": "data/table-for-two-release-history.json",
     "project": "AMEXPlatSG",
-    "updated_at": "2026-09-02T22:44:10+00:00",
+    "updated_at": "2026-09-03T09:50:42+00:00",
     "observation_count": 3258
   },
   "slot_source": {
@@ -418,51 +418,6 @@
       "explorer_route": "#/table-for-two?venue=tft-15-stamford-restaurant"
     },
     {
-      "id": "tft-baes-cocktail-club",
-      "name": "Bae's Cocktail Club",
-      "dining_city_id": "205194844",
-      "dining_city_name": "Bae's Cocktail Club",
-      "category": "restaurant",
-      "address": "21 Tanjong Pagar Road, #01-04/05, Singapore 088444",
-      "aliases": [],
-      "menus": {
-        "centurion": {
-          "status": "published",
-          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Baes-Menu_Centurion.pdf",
-          "filename": "Baes-Menu_Centurion.pdf",
-          "card": "centurion",
-          "label": "Centurion",
-          "checked_at": "2026-09-02T22:48:18Z",
-          "last_seen_at": "2026-09-02T22:48:18Z",
-          "sha256": "890f1bcc888eb30792754d3c6dd8260a5cbd9ccf3509ee8632ce6b044dc7b8bc"
-        },
-        "platinum": {
-          "status": "published",
-          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Baes-Menu_Platinum.pdf",
-          "filename": "Baes-Menu_Platinum.pdf",
-          "card": "platinum",
-          "label": "Platinum",
-          "checked_at": "2026-09-02T22:48:18Z",
-          "last_seen_at": "2026-09-02T22:48:18Z",
-          "sha256": "84893b90ec4f378f71bb9a44058d3c65b9071c2f1d7e1cec7c0f9b31da22015a"
-        }
-      },
-      "release_patterns": [
-        {
-          "meal": "Dinner",
-          "observation_count": 12,
-          "median_lead_days": 29.0,
-          "lead_days_min": 28,
-          "lead_days_max": 29,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.58,
-          "confidence": "medium",
-          "latest_observation_at": "2026-09-02T17:37:37Z"
-        }
-      ],
-      "explorer_route": "#/table-for-two?venue=tft-baes-cocktail-club"
-    },
-    {
       "id": "tft-brewerkz-east-coast-park",
       "name": "Brewerkz East Coast Park",
       "dining_city_id": "205196412",
@@ -521,49 +476,6 @@
       "explorer_route": "#/table-for-two?venue=tft-brewerkz-riverside-point"
     },
     {
-      "id": "tft-colony",
-      "name": "Colony",
-      "dining_city_id": "205191500",
-      "dining_city_name": "Colony",
-      "category": "buffet",
-      "address": "The Ritz-Carlton, Millenia Singapore, 7 Raffles Avenue, Singapore 039799",
-      "aliases": [
-        "Colony at the Ritz Carlton",
-        "Colony Ritz Carlton"
-      ],
-      "menus": {
-        "default": {
-          "status": "buffet_no_menu_expected",
-          "checked_at": "2026-09-02T22:48:18Z"
-        }
-      },
-      "release_patterns": [
-        {
-          "meal": "Dinner",
-          "observation_count": 25,
-          "median_lead_days": 35.0,
-          "lead_days_min": 3,
-          "lead_days_max": 61,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.24,
-          "confidence": "high",
-          "latest_observation_at": "2026-08-31T00:47:42Z"
-        },
-        {
-          "meal": "Lunch",
-          "observation_count": 18,
-          "median_lead_days": 61.0,
-          "lead_days_min": 7,
-          "lead_days_max": 61,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.33,
-          "confidence": "high",
-          "latest_observation_at": "2026-09-02T17:37:37Z"
-        }
-      ],
-      "explorer_route": "#/table-for-two?venue=tft-colony"
-    },
-    {
       "id": "tft-cultivate",
       "name": "Cultivate",
       "dining_city_id": "205194002",
@@ -620,90 +532,6 @@
         }
       ],
       "explorer_route": "#/table-for-two?venue=tft-cultivate"
-    },
-    {
-      "id": "tft-estate",
-      "name": "Estate",
-      "dining_city_id": "205195358",
-      "dining_city_name": "Estate",
-      "category": "buffet",
-      "address": "Hilton Singapore Orchard, Level 5, 333 Orchard Road, Singapore 238867",
-      "aliases": [],
-      "menus": {
-        "default": {
-          "status": "buffet_no_menu_expected",
-          "checked_at": "2026-09-02T22:48:18Z"
-        }
-      },
-      "release_patterns": [
-        {
-          "meal": "Afternoon Tea",
-          "observation_count": 11,
-          "median_lead_days": 61.0,
-          "lead_days_min": 61,
-          "lead_days_max": 61,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.36,
-          "confidence": "medium",
-          "latest_observation_at": "2026-09-02T09:37:48Z"
-        },
-        {
-          "meal": "Dinner",
-          "observation_count": 13,
-          "median_lead_days": 61.0,
-          "lead_days_min": 7,
-          "lead_days_max": 61,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.54,
-          "confidence": "medium",
-          "latest_observation_at": "2026-09-02T13:52:57Z"
-        },
-        {
-          "meal": "Lunch",
-          "observation_count": 11,
-          "median_lead_days": 61.0,
-          "lead_days_min": 61,
-          "lead_days_max": 61,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.36,
-          "confidence": "medium",
-          "latest_observation_at": "2026-09-02T05:05:57Z"
-        }
-      ],
-      "explorer_route": "#/table-for-two?venue=tft-estate"
-    },
-    {
-      "id": "tft-forage",
-      "name": "Forage",
-      "dining_city_id": "205193590",
-      "dining_city_name": "Forage",
-      "category": "restaurant",
-      "address": "60 Mandai Lake Road, Singapore 729979",
-      "aliases": [],
-      "menus": {
-        "centurion": {
-          "status": "published",
-          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Forage-Menu_Centurion.pdf",
-          "filename": "Forage-Menu_Centurion.pdf",
-          "card": "centurion",
-          "label": "Centurion",
-          "checked_at": "2026-09-02T22:48:18Z",
-          "last_seen_at": "2026-09-02T22:48:18Z",
-          "sha256": "cf8f3c26ca57769df8e9b845d76afe7cec261f23625b77930f4aced51b9fc127"
-        },
-        "platinum": {
-          "status": "published",
-          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Forage-Menu_Platinium.pdf",
-          "filename": "Forage-Menu_Platinium.pdf",
-          "card": "platinum",
-          "label": "Platinum",
-          "checked_at": "2026-09-02T22:48:18Z",
-          "last_seen_at": "2026-09-02T22:48:18Z",
-          "sha256": "72c0b83a7423c846dfca177ed203329ac81ae211979ca37557885be8090ed62d"
-        }
-      },
-      "release_patterns": [],
-      "explorer_route": "#/table-for-two?venue=tft-forage"
     },
     {
       "id": "tft-ginger",
@@ -777,51 +605,6 @@
       "explorer_route": "#/table-for-two?venue=tft-grand-cru-wine-bar"
     },
     {
-      "id": "tft-highhouse",
-      "name": "HighHouse",
-      "dining_city_id": "205194016",
-      "dining_city_name": "HighHouse",
-      "category": "restaurant",
-      "address": "1 Raffles Place, Level 61-62, Singapore 048616",
-      "aliases": [],
-      "menus": {
-        "centurion": {
-          "status": "published",
-          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/HighHouse-Menu_Centurion.pdf",
-          "filename": "HighHouse-Menu_Centurion.pdf",
-          "card": "centurion",
-          "label": "Centurion",
-          "checked_at": "2026-09-02T22:48:18Z",
-          "last_seen_at": "2026-09-02T22:48:18Z",
-          "sha256": "988388d5cd4de95b0688c9ea4a4f874c444f4ea4ac8624d58c6b909bea1affff"
-        },
-        "platinum": {
-          "status": "published",
-          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/HighHouse-Menu_Platinum.pdf",
-          "filename": "HighHouse-Menu_Platinum.pdf",
-          "card": "platinum",
-          "label": "Platinum",
-          "checked_at": "2026-09-02T22:48:18Z",
-          "last_seen_at": "2026-09-02T22:48:18Z",
-          "sha256": "e4b9865c94f3fa05fe893465a756cabd8c28b7a5e42b60bf4cf676d933e8b794"
-        }
-      },
-      "release_patterns": [
-        {
-          "meal": "Dinner",
-          "observation_count": 11,
-          "median_lead_days": 29.0,
-          "lead_days_min": 10,
-          "lead_days_max": 29,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.55,
-          "confidence": "medium",
-          "latest_observation_at": "2026-09-02T17:37:37Z"
-        }
-      ],
-      "explorer_route": "#/table-for-two?venue=tft-highhouse"
-    },
-    {
       "id": "tft-kaya-at-the-standard",
       "name": "Kaya at The Standard",
       "dining_city_id": "205192104",
@@ -878,65 +661,6 @@
       "explorer_route": "#/table-for-two?venue=tft-kaya-at-the-standard"
     },
     {
-      "id": "tft-kees",
-      "name": "Kee's",
-      "dining_city_id": "205194842",
-      "dining_city_name": "Kee's",
-      "category": "cafe",
-      "address": "21 Carpenter Street, Singapore 059984",
-      "aliases": [
-        "Kees"
-      ],
-      "menus": {
-        "platinum": {
-          "status": "published",
-          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Kees-Menu.pdf",
-          "filename": "Kees-Menu.pdf",
-          "card": "platinum",
-          "label": "Platinum",
-          "checked_at": "2026-09-02T22:48:18Z",
-          "last_seen_at": "2026-09-02T22:48:18Z",
-          "sha256": "b23f3d03b26133c35e5c5722051cdcd968fc87b7426a9f6a2be1df51dbd7f03f"
-        }
-      },
-      "release_patterns": [
-        {
-          "meal": "Afternoon Tea",
-          "observation_count": 16,
-          "median_lead_days": 61.0,
-          "lead_days_min": 61,
-          "lead_days_max": 61,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.31,
-          "confidence": "high",
-          "latest_observation_at": "2026-09-02T09:37:48Z"
-        },
-        {
-          "meal": "Dinner",
-          "observation_count": 17,
-          "median_lead_days": 61.0,
-          "lead_days_min": 5,
-          "lead_days_max": 61,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.35,
-          "confidence": "high",
-          "latest_observation_at": "2026-09-02T09:37:48Z"
-        },
-        {
-          "meal": "Lunch",
-          "observation_count": 15,
-          "median_lead_days": 61.0,
-          "lead_days_min": 61,
-          "lead_days_max": 61,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.33,
-          "confidence": "high",
-          "latest_observation_at": "2026-09-02T05:05:57Z"
-        }
-      ],
-      "explorer_route": "#/table-for-two?venue=tft-kees"
-    },
-    {
       "id": "tft-la-brasserie",
       "name": "La Brasserie",
       "dining_city_id": "205173372",
@@ -991,62 +715,6 @@
         }
       ],
       "explorer_route": "#/table-for-two?venue=tft-la-brasserie"
-    },
-    {
-      "id": "tft-latido",
-      "name": "Latido",
-      "dining_city_id": "205195352",
-      "dining_city_name": "Latido",
-      "category": "restaurant",
-      "address": "40 Tras Street, Singapore 078979",
-      "aliases": [],
-      "menus": {
-        "centurion": {
-          "status": "published",
-          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/centurion/dining-and-lifestyle/Latido-Menu_Centurion.pdf",
-          "filename": "Latido-Menu_Centurion.pdf",
-          "card": "centurion",
-          "label": "Centurion",
-          "checked_at": "2026-09-02T22:48:18Z",
-          "last_seen_at": "2026-09-02T22:48:18Z",
-          "sha256": "33d9f7f4f446b5b83bfa8c7febe97eebb663a68563e333b392df6ae24dd07401"
-        },
-        "platinum": {
-          "status": "published",
-          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Latido-Menu_Platinum.pdf",
-          "filename": "Latido-Menu_Platinum.pdf",
-          "card": "platinum",
-          "label": "Platinum",
-          "checked_at": "2026-09-02T22:48:18Z",
-          "last_seen_at": "2026-09-02T22:48:18Z",
-          "sha256": "e71475b254c01b21f3d6371d55c9765f5c1b032d2f9ea351ea7a541ce63cf541"
-        }
-      },
-      "release_patterns": [
-        {
-          "meal": "Dinner",
-          "observation_count": 14,
-          "median_lead_days": 61.0,
-          "lead_days_min": 4,
-          "lead_days_max": 61,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.29,
-          "confidence": "medium",
-          "latest_observation_at": "2026-09-02T13:52:57Z"
-        },
-        {
-          "meal": "Lunch",
-          "observation_count": 10,
-          "median_lead_days": 61.0,
-          "lead_days_min": 61,
-          "lead_days_max": 61,
-          "typical_first_seen_sgt": null,
-          "typical_time_observation_share": 0.4,
-          "confidence": "medium",
-          "latest_observation_at": "2026-08-31T06:41:44Z"
-        }
-      ],
-      "explorer_route": "#/table-for-two?venue=tft-latido"
     },
     {
       "id": "tft-one-ninety",

--- a/reminders/tests/test_tft_guide.py
+++ b/reminders/tests/test_tft_guide.py
@@ -25,6 +25,19 @@ def _catalog() -> dict:
     return tft_guide.load_catalog()
 
 
+def _buffet_venue(catalog: dict) -> dict:
+    # Buffet venues come and go from the booking project, so pick one from the
+    # catalogue instead of naming a venue the roster may drop.
+    return next(
+        venue
+        for venue in catalog["venues"]
+        if any(
+            menu.get("status") == "buffet_no_menu_expected"
+            for menu in venue["menus"].values()
+        )
+    )
+
+
 def test_generated_catalog_matches_current_tft_source():
     module_path = ROOT / "scripts" / "build_tft_guide_catalog.py"
     spec = importlib.util.spec_from_file_location("build_tft_guide_catalog", module_path)
@@ -177,7 +190,9 @@ def test_missing_and_buffet_menu_states_are_honest():
     missing = tft_guide.handle_message(
         "/menu One Ninety platinum", _catalog(), NOW
     )
-    buffet = tft_guide.handle_message("/menu Colony platinum", _catalog(), NOW)
+    buffet = tft_guide.handle_message(
+        f"/menu {_buffet_venue(_catalog())['name']} platinum", _catalog(), NOW
+    )
 
     assert "No official PDF was matched" in missing
     assert "does not prove no menu exists" in missing
@@ -210,12 +225,13 @@ def test_absent_requested_variant_shows_source_freshness_and_nonexistence_caveat
 def test_missing_and_buffet_states_show_stale_and_specific_review_context():
     catalog = copy.deepcopy(_catalog())
     stale = (NOW - timedelta(hours=37)).isoformat()
-    for venue_id in ("tft-one-ninety", "tft-colony"):
+    buffet_venue = _buffet_venue(catalog)
+    for venue_id in ("tft-one-ninety", buffet_venue["id"]):
         venue = next(item for item in catalog["venues"] if item["id"] == venue_id)
         venue["menus"]["default"]["checked_at"] = stale
 
     missing = tft_guide.handle_message("/menu One Ninety", catalog, NOW)
-    buffet = tft_guide.handle_message("/menu Colony", catalog, NOW)
+    buffet = tft_guide.handle_message(f"/menu {buffet_venue['name']}", catalog, NOW)
 
     for answer in (missing, buffet):
         assert "Menu index checked:" in answer

--- a/reminders/tests/test_tft_slots.py
+++ b/reminders/tests/test_tft_slots.py
@@ -37,6 +37,17 @@ def snapshot() -> dict:
     return payload
 
 
+def other_venue(payload: dict) -> tuple[dict, str]:
+    # The booking project drops and re-adds venues, so take a second venue from the
+    # snapshot instead of naming one the roster may remove.
+    names = {venue["id"]: venue["name"] for venue in catalog()["venues"]}
+    return next(
+        (venue, names[venue["id"]])
+        for venue in payload["venues"]
+        if venue["id"] != "tft-vue" and venue["id"] in names
+    )
+
+
 def answer(command: str, payload: dict | None = None) -> str:
     return tft_guide.handle_message(
         command,
@@ -129,7 +140,7 @@ def test_per_venue_staleness_overrides_recent_top_level_generation_time():
 
 def test_weekend_any_uses_transparent_next_30_day_defaults():
     payload = snapshot()
-    venue = next(item for item in payload["venues"] if item["id"] == "tft-colony")
+    venue, venue_name = other_venue(payload)
     venue["checked_at"] = (NOW - timedelta(minutes=5)).isoformat()
     venue["project"] = "AMEXPlatSG"
     venue["status"] = "live_available"
@@ -146,7 +157,7 @@ def test_weekend_any_uses_transparent_next_30_day_defaults():
 
     result = answer("/slots any | 2 | dinner | weekend", payload)
 
-    assert "Colony — 2026-09-05 19:00" in result
+    assert f"{venue_name} — 2026-09-05 19:00" in result
     assert "2026-09-07" not in result
     assert "weekends in the next 30 days" in result
     assert (
@@ -158,9 +169,10 @@ def test_weekend_any_uses_transparent_next_30_day_defaults():
 
 def test_conversational_weekend_query_defaults_transparently_and_checks_both_meals():
     payload = snapshot()
+    lunch_venue, lunch_venue_name = other_venue(payload)
     for venue_id, meal, slot_date in (
         ("tft-vue", "Dinner", "2026-09-05"),
-        ("tft-colony", "Lunch", "2026-09-06"),
+        (lunch_venue["id"], "Lunch", "2026-09-06"),
     ):
         venue = next(item for item in payload["venues"] if item["id"] == venue_id)
         venue["checked_at"] = (NOW - timedelta(minutes=5)).isoformat()
@@ -185,7 +197,7 @@ def test_conversational_weekend_query_defaults_transparently_and_checks_both_mea
     )
 
     assert "VUE — 2026-09-05 19:00, dinner" in result
-    assert "Colony — 2026-09-06 19:00, lunch" in result
+    assert f"{lunch_venue_name} — 2026-09-06 19:00, lunch" in result
     assert "Filters: 2 pax, Lunch or Dinner, weekends in the next 30 days" in result
     assert calls == 1
 

--- a/scripts/scrape_table_for_two.py
+++ b/scripts/scrape_table_for_two.py
@@ -1686,7 +1686,7 @@ def build_payload(
         else (existing_payload or {}).get("availability_last_checked_at")
     )
 
-    return {
+    payload = {
         "dataset": "table_for_two",
         "program": "American Express Table for Two by Platinum",
         "country": "Singapore",
@@ -1761,6 +1761,11 @@ def build_payload(
             booking_project_source,
         ),
     }
+    # The roster refresh does not own menu review state. Dropping it would strand the
+    # published menus without their approved decision receipts.
+    if "menu_source" in (existing_payload or {}):
+        payload["menu_source"] = existing_payload["menu_source"]
+    return payload
 
 
 def refresh_availability_payload(existing_payload: dict, *, include_profiles: bool = False) -> dict:

--- a/scripts/tests/test_tft_menu_reviews.py
+++ b/scripts/tests/test_tft_menu_reviews.py
@@ -254,6 +254,15 @@ def test_receipt_verifier_rejects_unbound_reviewed_menu():
         tft_menu_reviews.verify_decision_receipts(payload)
 
 
+def test_receipt_verifier_keeps_history_for_a_delisted_venue():
+    payload, manifest, _item, _previous = fixture()
+    updated, _event = tft_menu_reviews.apply_review(payload, manifest, PDF, now=NOW)
+
+    updated["venues"] = []
+
+    tft_menu_reviews.verify_decision_receipts(updated)
+
+
 @pytest.mark.parametrize(
     "tamper",
     [

--- a/scripts/tests/test_tft_menu_state_retention.py
+++ b/scripts/tests/test_tft_menu_state_retention.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import scrape_table_for_two
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_roster_refresh_keeps_menu_review_state(monkeypatch, tmp_path) -> None:
+    existing = json.loads((ROOT / "data/table-for-two.json").read_text())
+    existing["menu_source"] = {"review_decisions": [{"candidate_id": "a" * 64}]}
+
+    def fetch(url: str) -> bytes:
+        if url == scrape_table_for_two.OFFICIAL_URL:
+            return b"official page"
+        if url in (scrape_table_for_two.TERMS_URL, scrape_table_for_two.FAQ_URL):
+            return b"%PDF-1.4\nstable document\n%%EOF\n"
+        return b"image"
+
+    monkeypatch.setattr(scrape_table_for_two, "fetch_bytes", fetch)
+    monkeypatch.setattr(
+        scrape_table_for_two,
+        "extract_image_url",
+        lambda _html, alt: (
+            "https://example.test/participating.png"
+            if alt == "Participating Merchants"
+            else "https://example.test/cycles.png"
+        ),
+    )
+    monkeypatch.setattr(
+        scrape_table_for_two.tft_roster_reviews,
+        "review_state",
+        lambda *_args: ([], {"review_required": False}),
+    )
+    monkeypatch.setattr(
+        scrape_table_for_two, "fetch_live_availability", lambda *_args: ({}, {})
+    )
+    monkeypatch.setattr(
+        scrape_table_for_two, "fetch_diningcity_profiles", lambda *_args: ({}, {})
+    )
+
+    refreshed = scrape_table_for_two.build_payload(existing, tmp_path)
+
+    assert refreshed["menu_source"] == existing["menu_source"]

--- a/scripts/tft_menu_reviews.py
+++ b/scripts/tft_menu_reviews.py
@@ -452,17 +452,18 @@ def verify_decision_receipts(payload: dict) -> None:
             if entry.get("owner_event") is not None:
                 raise ValueError("rejected TFT menu decision cannot publish an event")
             continue
-        event = entry.get("owner_event") or {}
         venue = venues.get(candidate.get("venue_id"))
+        if not venue:
+            # The venue left the roster after this menu was approved. The receipt stays
+            # as history; it no longer authorizes a published menu.
+            continue
+        event = entry.get("owner_event") or {}
         expected_event = _owner_event(
             candidate_item,
             manifest,
-            str((venue or {}).get("name") or ""),
+            str(venue.get("name") or ""),
         )
-        if (
-            not venue
-            or event != expected_event
-        ):
+        if event != expected_event:
             raise ValueError("approved TFT menu decision has an invalid owner event")
         approved_by_manifest[entry["manifest_sha256"]] = entry
         key = (str(candidate.get("venue_id")), str(candidate.get("card")))


### PR DESCRIPTION
## Why the alert emails

`Table for Two Alerts` has failed on every schedule since 2026-09-02, and `Refresh Table for Two` failed too. Both die on the same error:

```
ValueError: reviewed TFT menu lacks an approved decision receipt
  scripts/tft_menu_reviews.py:487 in verify_decision_receipts
```

## Root cause

`scrape_table_for_two.build_payload` rebuilds `data/table-for-two.json` from a fresh dict and never carried `menu_source` over. Normally `fetch_tft_menus.py` runs later in the same workflow and writes `menu_source` back, so the gap was invisible while `review_decisions` was empty.

On 2026-09-02 the ledger held three approved receipts. The roster refresh dropped them, `fetch_tft_menus.py` re-added a `menu_source` without them, and the published Sarnies menu was left holding a `review_manifest_sha256` with no matching receipt. Every later run fails closed on that mismatch, including the alert job.

A second gap surfaced during recovery: Forage was delisted from the DiningCity booking project after its menus were approved, and `verify_decision_receipts` raised on any approved receipt whose venue is no longer in the roster.

## Changes

- `build_payload` carries `menu_source` over from the existing payload.
- `verify_decision_receipts` treats an approved receipt for a delisted venue as history. The invariant that every *published* menu has an approved receipt is unchanged.
- Restored the lost `menu_source` block into `data/table-for-two.json` and rebuilt `reminders/app/tft_guide_catalog.json`, which had been stale since the build started failing (28 → 21 active venues; 8 are now `not_listed`).
- The reminders tests picked `Colony` by name for their buffet and secondary-venue cases. Colony left the booking project, so they now select a venue from the catalogue.

## Verification

- Two new regression tests fail without the fixes and pass with them.
- `scripts/tests` + `reminders/tests`: 542 passed. `node --test scripts/tests/*.js`: 18 passed.
- `build_tft_guide_catalog.py`, `build_tft_slot_snapshot.py`, and `fetch_tft_menus.py --dry-run` all run clean against the repaired data.

https://claude.ai/code/session_01R8A3zoZuYT1xZsch9oVKgn