### PR TITLE
fix: revalidate the Table for Two roster in an open tab

### DIFF
--- a/scripts/tests/test_tft_catalog_revalidation.js
+++ b/scripts/tests/test_tft_catalog_revalidation.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const vm = require("node:vm");
+
+const source = fs.readFileSync("web/app.js", "utf8");
+
+function extractFunction(name) {
+  const start = source.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`Missing ${name}`);
+  // The parameter list destructures an options object, so skip past its parens
+  // before looking for the body brace.
+  let parens = 0;
+  let cursor = source.indexOf("(", start);
+  for (; cursor < source.length; cursor += 1) {
+    if (source[cursor] === "(") parens += 1;
+    if (source[cursor] === ")") parens -= 1;
+    if (parens === 0) break;
+  }
+  const bodyStart = source.indexOf("{", cursor);
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") depth -= 1;
+    if (depth === 0) return `async ${source.slice(start, index + 1)}`;
+  }
+  throw new Error(`Unclosed ${name}`);
+}
+
+function harness({ catalog, slots = { venues: [] }, releaseHistory = { observations: [] } }) {
+  const calls = { fetched: [], rendered: 0, liveRefreshed: 0, snapshots: [] };
+  const context = {
+    state: {
+      dataLoaded: { tableForTwo: true },
+      tableForTwo: { venues: [{ id: "tft-colony", name: "Colony" }] },
+      tableForTwoReleaseHistory: { observations: ["stale"] },
+      tableForTwoDataRevalidatedAt: null,
+      tableForTwoDataRevalidateInFlight: false,
+      tableForTwoLiveRefreshAt: 1,
+    },
+    TABLE_FOR_TWO_DATA_URL: "catalog",
+    TABLE_FOR_TWO_DATA_FALLBACK_URL: "catalog-fallback",
+    TABLE_FOR_TWO_STATIC_SNAPSHOT_URL: "slots",
+    TABLE_FOR_TWO_RELEASE_HISTORY_URL: "release",
+    TABLE_FOR_TWO_RELEASE_HISTORY_FALLBACK_URL: "release-fallback",
+    TABLE_FOR_TWO_DATA_REVALIDATE_INTERVAL_MS: 5 * 60 * 1000,
+    fetchJson: async (url) => {
+      calls.fetched.push(url);
+      if (url === "catalog") return catalog;
+      if (url === "slots") return slots;
+      if (url === "release") return releaseHistory;
+      return null;
+    },
+    applyTableForTwoStaticSnapshot: (payload) => calls.snapshots.push(payload),
+    tableForTwoVenues: () => context.state.tableForTwo.venues || [],
+    tableForTwoSearchText: (record) => record.name,
+    refreshTableForTwoCategoryOptions: () => {},
+    isTableForTwoRoute: () => true,
+    refreshTableForTwoDateOptions: () => {},
+    filterTableForTwo: () => {
+      calls.rendered += 1;
+    },
+    refreshTableForTwoLiveAvailability: async () => {
+      calls.liveRefreshed += 1;
+    },
+    Date,
+  };
+  vm.runInNewContext(
+    `${extractFunction("revalidateTableForTwoData")}\nglobalThis.revalidateTableForTwoData = revalidateTableForTwoData;`,
+    context,
+  );
+  return { context, calls };
+}
+
+(async () => {
+  // A tab left open must pick up a roster published after it loaded.
+  const fresh = {
+    venues: [
+      { id: "tft-colony", name: "Colony", booking_project_status: "not_listed" },
+      { id: "tft-park90", name: "Park90", booking_project_status: "active" },
+    ],
+    availability_last_checked_at: "2026-09-03T12:21:06Z",
+  };
+  const { context, calls } = harness({ catalog: fresh });
+
+  await context.revalidateTableForTwoData();
+
+  assert.equal(context.state.tableForTwo.availability_last_checked_at, "2026-09-03T12:21:06Z");
+  assert.deepEqual(
+    context.state.tableForTwo.venues.map((venue) => venue.id),
+    ["tft-colony", "tft-park90"],
+  );
+  assert.equal(context.state.tableForTwo.venues[0].booking_project_status, "not_listed");
+  assert.equal(context.state.tableForTwoReleaseHistory.observations.length, 0);
+  assert.equal(calls.rendered, 1);
+  assert.equal(calls.liveRefreshed, 1);
+  assert.equal(context.state.tableForTwoLiveRefreshAt, null);
+  assert.ok(context.state.tableForTwoDataRevalidatedAt);
+
+  // A second call inside the interval must not refetch.
+  const before = calls.fetched.length;
+  await context.revalidateTableForTwoData();
+  assert.equal(calls.fetched.length, before);
+
+  // Forcing past the interval refetches.
+  await context.revalidateTableForTwoData({ force: true });
+  assert.ok(calls.fetched.length > before);
+
+  // A failed catalog fetch keeps the roster already on screen.
+  const failed = harness({ catalog: null });
+  await failed.context.revalidateTableForTwoData();
+  assert.deepEqual(
+    failed.context.state.tableForTwo.venues.map((venue) => venue.id),
+    ["tft-colony"],
+  );
+  assert.equal(failed.calls.rendered, 0);
+
+  // Every refetched file must bypass the 600s browser cache, or revalidation is a no-op.
+  const revalidated = source.slice(
+    source.indexOf("const REVALIDATE_DATA_URLS"),
+    source.indexOf("]);", source.indexOf("const REVALIDATE_DATA_URLS")),
+  );
+  for (const name of [
+    "TABLE_FOR_TWO_DATA_URL",
+    "TABLE_FOR_TWO_DATA_FALLBACK_URL",
+    "TABLE_FOR_TWO_STATIC_SNAPSHOT_URL",
+    "TABLE_FOR_TWO_RELEASE_HISTORY_URL",
+    "TABLE_FOR_TWO_RELEASE_HISTORY_FALLBACK_URL",
+  ]) {
+    assert.ok(revalidated.includes(name), `${name} must revalidate`);
+  }
+
+  // The refresh must be wired to both the timer and returning to the tab.
+  const wiring = source.slice(source.indexOf("function ensureTableForTwoLiveRefresh("));
+  assert.ok(wiring.includes("visibilitychange"), "must refresh when the tab becomes visible");
+  assert.ok(
+    wiring.indexOf("revalidateTableForTwoData") < wiring.indexOf("TABLE_FOR_TWO_LIVE_REFRESH_INTERVAL_MS"),
+    "must refresh on the live interval",
+  );
+
+  console.log("tft catalog revalidation ok");
+})();

--- a/web/app.js
+++ b/web/app.js
@@ -101,6 +101,7 @@ const GOOGLE_RATING_STALE_DAYS = 90;
 const REMINDERS_API_BASE = "https://amex-reminders-production.up.railway.app";
 const TABLE_FOR_TWO_LIVE_SNAPSHOT_URL = `${REMINDERS_API_BASE}/api/tft/slots`;
 const TABLE_FOR_TWO_LIVE_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const TABLE_FOR_TWO_DATA_REVALIDATE_INTERVAL_MS = 5 * 60 * 1000;
 const TABLE_FOR_TWO_FETCH_TIMEOUT_MS = 12 * 1000;
 const TABLE_FOR_TWO_DEFAULT_PARTY_SIZE = 2;
 const TABLE_FOR_TWO_MAX_TIMES = 12;
@@ -108,6 +109,10 @@ const TABLE_FOR_TWO_TIME_WINDOW_MINUTES = 60;
 const TABLE_FOR_TWO_TIME_WINDOW_LABEL = "1 hour";
 const REVALIDATE_DATA_URLS = new Set([
   TABLE_FOR_TWO_DATA_URL,
+  TABLE_FOR_TWO_DATA_FALLBACK_URL,
+  TABLE_FOR_TWO_STATIC_SNAPSHOT_URL,
+  TABLE_FOR_TWO_RELEASE_HISTORY_URL,
+  TABLE_FOR_TWO_RELEASE_HISTORY_FALLBACK_URL,
   UPDATES_DATA_URL,
   SOURCE_HEALTH_DATA_URL,
 ]);
@@ -550,6 +555,9 @@ const state = {
   pocketCalendarMonths: {},
   pocketCalendarOpen: {},
   japanRankFiltersOpen: false,
+  tableForTwoVisibilityBound: false,
+  tableForTwoDataRevalidatedAt: null,
+  tableForTwoDataRevalidateInFlight: false,
   tableForTwoLiveRefreshInFlight: false,
   tableForTwoLiveRefreshAt: null,
   tableForTwoLiveRefreshTimer: null,
@@ -5400,13 +5408,64 @@ async function refreshTableForTwoLiveAvailability({ force = false } = {}) {
   }
 }
 
+async function revalidateTableForTwoData({ force = false } = {}) {
+  if (!state.dataLoaded.tableForTwo || state.tableForTwoDataRevalidateInFlight) return;
+  const now = Date.now();
+  if (
+    !force
+    && state.tableForTwoDataRevalidatedAt
+    && now - state.tableForTwoDataRevalidatedAt < TABLE_FOR_TWO_DATA_REVALIDATE_INTERVAL_MS
+  ) {
+    return;
+  }
+
+  state.tableForTwoDataRevalidateInFlight = true;
+  try {
+    const [tableForTwo, staticSlots, releaseHistory] = await Promise.all([
+      fetchJson(TABLE_FOR_TWO_DATA_URL)
+        .then((payload) => payload || fetchJson(TABLE_FOR_TWO_DATA_FALLBACK_URL)),
+      fetchJson(TABLE_FOR_TWO_STATIC_SNAPSHOT_URL),
+      fetchJson(TABLE_FOR_TWO_RELEASE_HISTORY_URL)
+        .then((payload) => payload || fetchJson(TABLE_FOR_TWO_RELEASE_HISTORY_FALLBACK_URL)),
+    ]);
+    state.tableForTwoDataRevalidatedAt = Date.now();
+    // Keep the loaded payload when a fetch fails; a stale roster beats an empty one.
+    if (!tableForTwo) return;
+    state.tableForTwo = tableForTwo;
+    applyTableForTwoStaticSnapshot(staticSlots);
+    if (releaseHistory) state.tableForTwoReleaseHistory = releaseHistory;
+    tableForTwoVenues().forEach((record) => {
+      record.search_text = tableForTwoSearchText(record);
+    });
+    refreshTableForTwoCategoryOptions();
+    // The replaced payload dropped the live overlay, so re-apply it now.
+    state.tableForTwoLiveRefreshAt = null;
+    if (isTableForTwoRoute()) {
+      refreshTableForTwoDateOptions();
+      filterTableForTwo();
+    }
+    await refreshTableForTwoLiveAvailability();
+  } finally {
+    state.tableForTwoDataRevalidateInFlight = false;
+  }
+}
+
 function ensureTableForTwoLiveRefresh() {
   if (!state.tableForTwoLiveRefreshTimer) {
     state.tableForTwoLiveRefreshTimer = window.setInterval(() => {
       if (isTableForTwoRoute()) {
+        void revalidateTableForTwoData();
         refreshTableForTwoLiveAvailability();
       }
     }, TABLE_FOR_TWO_LIVE_REFRESH_INTERVAL_MS);
+  }
+  if (!state.tableForTwoVisibilityBound) {
+    state.tableForTwoVisibilityBound = true;
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState !== "visible" || !isTableForTwoRoute()) return;
+      void revalidateTableForTwoData();
+      refreshTableForTwoLiveAvailability();
+    });
   }
   refreshTableForTwoLiveAvailability();
 }


### PR DESCRIPTION
## What was stale

The pipeline and the server were fine. `data/table-for-two-catalog.json` on production carries 29 venues, 8 `not_listed`, checked `2026-09-03T12:21:06Z`. The staleness was in the browser.

`web/app.js` fetched the roster catalogue, slot snapshot and release history **once per page load**. Only live availability had a refresh timer, and that only overlays slot counts. So a tab left open kept rendering the roster it fetched at load.

The reported symptoms match exactly. "Checked 2 Sept 2026, 1:37 am" plus "Official menu index checked 1 Sept 2026, 8:58 am" is the pair from commit `15db1e6`, deployed 1 Sept 17:39 UTC. That is why venues that had since left the booking project (Colony, Estate, Bae's, HighHouse, Kee's, Latido) still showed as bookable beside a fresh "Observed through 3 Sept 2026, 8:21 pm".

## Changes

- `revalidateTableForTwoData()` refetches the catalogue, slot snapshot and release history, re-applies the live overlay, and re-renders. A failed fetch keeps the roster already on screen rather than blanking it.
- Wired to the existing 5 minute live-refresh interval and to `visibilitychange`, so returning to the tab refreshes it.
- Added the slot snapshot and release-history URLs to `REVALIDATE_DATA_URLS`. Without that they come from the 600s browser cache and the refetch is a no-op.

## Verification

- `scripts/tests/test_tft_catalog_revalidation.js` covers the replace, the interval guard, the failed-fetch fallback, the cache allowlist and the wiring. It fails without the fix.
- Chromium end-to-end: published a roster change under an already-open page, then triggered tab focus. The renamed venue appeared and the removed venue disappeared, no page errors. The same test against the previous `app.js` fails.
- Full suite: 542 Python tests, 19 node tests.

https://claude.ai/code/session_01R8A3zoZuYT1xZsch9oVKgn