### PR TITLE
feat: retry or escalate stale refresh sources

### DIFF
--- a/.github/workflows/match-tabelog-candidates.yml
+++ b/.github/workflows/match-tabelog-candidates.yml
@@ -1,6 +1,9 @@
 name: Match Tabelog Candidates
 
 on:
+  schedule:
+    # Monthly candidate sweep so the Japan Tabelog matches do not drift unseen.
+    - cron: "0 3 1 * *"
   workflow_dispatch:
     inputs:
       offset:
@@ -40,10 +43,10 @@ jobs:
       - name: Run Tabelog matcher batch
         env:
           PYTHONUNBUFFERED: "1"
-          INPUT_OFFSET: ${{ inputs.offset }}
-          INPUT_LIMIT: ${{ inputs.limit }}
-          INPUT_TOP: ${{ inputs.top }}
-          INPUT_PAUSE: ${{ inputs.pause }}
+          INPUT_OFFSET: ${{ inputs.offset || '0' }}
+          INPUT_LIMIT: ${{ inputs.limit || '50' }}
+          INPUT_TOP: ${{ inputs.top || '5' }}
+          INPUT_PAUSE: ${{ inputs.pause || '0.2' }}
         run: |
           [[ "$INPUT_OFFSET" =~ ^[0-9]+$ ]] || { echo "offset must be an integer"; exit 2; }
           [[ "$INPUT_LIMIT" =~ ^[0-9]+$ ]] || { echo "limit must be an integer"; exit 2; }
@@ -60,5 +63,5 @@ jobs:
       - name: Upload matcher output
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: tabelog-candidates-${{ inputs.offset }}-${{ inputs.limit }}
+          name: tabelog-candidates-${{ inputs.offset || '0' }}-${{ inputs.limit || '50' }}
           path: artifacts/

--- a/.github/workflows/monitor-source-health.yml
+++ b/.github/workflows/monitor-source-health.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  actions: write
+  issues: write
 
 concurrency:
   group: source-ledger-refresh
@@ -61,3 +63,9 @@ jobs:
       - name: Check live Table for Two freshness
         if: always()
         run: python3 scripts/check_tft_live_health.py
+
+      - name: Retry or escalate stale sources
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/watchdog_stale_sources.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,29 @@ Large binary/cache files are gitignored. Committed:
 
 ---
 
+## Staleness Watchdog
+
+`scripts/build_source_health.py` writes per-source freshness into `data/source-health.json`
+every 30 minutes (`Monitor Source Health`). `scripts/watchdog_stale_sources.py` then acts
+on it:
+
+- A source past its `stale_after_hours` limit, or with a non-clear `failure_state`, gets
+  its owning workflow re-dispatched (`SOURCE_WORKFLOWS`), at most once per workflow per
+  6 hours. Sources sharing a workflow collapse into one dispatch.
+- If a retry already ran inside that window and the source is still degraded, the watchdog
+  opens a single `source-health` issue. Only one is open at a time, so the 30-minute
+  cadence cannot spam it.
+- `tabelog-ratings` is intentionally unmapped. `Match Tabelog Candidates` uploads a
+  candidate artifact and commits nothing, so no retry can clear it. It escalates instead.
+
+`review_required` is a human review flag, not staleness, and never triggers the watchdog.
+
+Dry run without dispatching anything:
+
+```bash
+python3 scripts/watchdog_stale_sources.py --dry-run
+```
+
 ## Table for Two Reminders Service (`reminders/`)
 
 Self-hosted signup for Table for Two availability alerts. Replaced the old

--- a/scripts/tests/test_watchdog_stale_sources.py
+++ b/scripts/tests/test_watchdog_stale_sources.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts import watchdog_stale_sources as watchdog
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NOW = datetime(2026, 9, 4, 12, 0, tzinfo=timezone.utc)
+
+
+def source(source_id: str, *, freshness: str = "current", failure: str = "clear", review: str = "clear") -> dict:
+    return {
+        "id": source_id,
+        "freshness_state": freshness,
+        "failure_state": failure,
+        "review_state": review,
+        "checked_at": "2026-09-01T00:00:00Z",
+        "stale_after_hours": 36,
+    }
+
+
+def test_review_required_is_not_treated_as_stale() -> None:
+    pending = source("global-dining", review="required")
+
+    assert watchdog.is_degraded(pending) is False
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"freshness": "stale"},
+        {"freshness": "unavailable"},
+        {"failure": "failing"},
+    ],
+)
+def test_stale_or_failing_sources_need_attention(kwargs: dict) -> None:
+    assert watchdog.is_degraded(source("japan-dining", **kwargs)) is True
+
+
+def test_first_sighting_retries_the_owning_workflow() -> None:
+    stale = [source("japan-dining", freshness="stale")]
+
+    plans = watchdog.plan_actions(stale, {"Refresh Data": None}, NOW)
+
+    assert [(plan.workflow, plan.action) for plan in plans] == [
+        ("Refresh Data", watchdog.Action.DISPATCH)
+    ]
+
+
+def test_sources_sharing_a_workflow_dispatch_it_once() -> None:
+    stale = [
+        source("japan-dining", freshness="stale"),
+        source("plat-stay", freshness="stale"),
+    ]
+
+    plans = watchdog.plan_actions(stale, {"Refresh Data": None}, NOW)
+
+    assert len(plans) == 1
+    assert plans[0].source_ids == ("japan-dining", "plat-stay")
+
+
+def test_a_recent_retry_escalates_instead_of_dispatching_again() -> None:
+    stale = [source("japan-dining", freshness="stale")]
+
+    plans = watchdog.plan_actions(stale, {"Refresh Data": NOW - timedelta(hours=1)}, NOW)
+
+    assert plans[0].action is watchdog.Action.ESCALATE
+
+
+def test_a_retry_older_than_the_window_dispatches_again() -> None:
+    stale = [source("japan-dining", freshness="stale")]
+
+    plans = watchdog.plan_actions(stale, {"Refresh Data": NOW - timedelta(hours=7)}, NOW)
+
+    assert plans[0].action is watchdog.Action.DISPATCH
+
+
+def test_only_the_declared_manual_sources_lack_an_owning_workflow() -> None:
+    health = json.loads((ROOT / "data/source-health.json").read_text())
+
+    unowned = {s["id"] for s in health["sources"] if s["id"] not in watchdog.SOURCE_WORKFLOWS}
+
+    assert unowned == watchdog.UNOWNED_SOURCES
+
+
+def test_a_source_no_workflow_can_refresh_is_named_in_the_issue() -> None:
+    stale = [source("tabelog-ratings", freshness="stale")]
+
+    plans = watchdog.plan_actions(stale, {}, NOW)
+    body = watchdog.issue_body(stale, plans, NOW)
+
+    assert plans == []
+    assert "no workflow refreshes this" in body
+
+
+def test_every_mapped_workflow_exists_and_accepts_manual_dispatch() -> None:
+    workflows = {
+        path.read_text(encoding="utf-8").splitlines()[0].removeprefix("name: ").strip(): path
+        for path in (ROOT / ".github/workflows").glob("*.yml")
+    }
+
+    for name in set(watchdog.SOURCE_WORKFLOWS.values()):
+        assert name in workflows, f"{name} is not a workflow"
+        assert "workflow_dispatch:" in workflows[name].read_text(encoding="utf-8")
+
+
+def test_healthy_health_file_plans_nothing(tmp_path: Path) -> None:
+    health = tmp_path / "health.json"
+    health.write_text(json.dumps({"sources": [source("japan-dining")]}))
+
+    assert watchdog.main(["--health", str(health), "--dry-run"]) == 0
+    assert watchdog.degraded_sources(json.loads(health.read_text())) == []
+
+
+def test_issue_body_names_the_source_and_the_decision() -> None:
+    stale = [source("love-dining", freshness="stale")]
+    plans = watchdog.plan_actions(stale, {"Refresh Love Dining": NOW - timedelta(hours=1)}, NOW)
+
+    body = watchdog.issue_body(stale, plans, NOW)
+
+    assert "love-dining" in body
+    assert "Refresh Love Dining" in body
+    assert "escalate" in body
+
+
+def test_monitor_workflow_runs_the_watchdog_with_the_rights_it_needs() -> None:
+    workflow = (ROOT / ".github/workflows/monitor-source-health.yml").read_text()
+
+    assert "scripts/watchdog_stale_sources.py" in workflow
+    assert "actions: write" in workflow
+    assert "issues: write" in workflow
+
+
+def test_tabelog_candidates_runs_on_a_schedule_with_usable_defaults() -> None:
+    workflow = (ROOT / ".github/workflows/match-tabelog-candidates.yml").read_text()
+
+    assert "schedule:" in workflow
+    # A scheduled run carries no inputs, so every one needs a literal fallback.
+    for field, default in (("offset", "0"), ("limit", "50"), ("top", "5"), ("pause", "0.2")):
+        assert f"inputs.{field} || '{default}'" in workflow

--- a/scripts/watchdog_stale_sources.py
+++ b/scripts/watchdog_stale_sources.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Re-dispatch the workflow behind a stale source, then escalate if it stays stale.
+
+Source health already detects staleness every 30 minutes, but nothing acted on it,
+so a failed daily refresh waited a full day for its next cron. This closes that
+loop: one retry per owning workflow per window, then a single deduped issue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+
+DEFAULT_HEALTH_PATH = Path("data/source-health.json")
+RETRY_WINDOW_HOURS = 6
+DEGRADED_FRESHNESS = {"stale", "unavailable"}
+ISSUE_TITLE = "Source data is stale: refresh needs attention"
+ISSUE_LABEL = "source-health"
+
+# A source is refreshed by exactly one workflow. Several sources can share one.
+# `tabelog-ratings` is deliberately absent: Match Tabelog Candidates uploads a
+# candidate artifact and commits nothing, so a retry cannot clear its staleness.
+# It escalates to the issue instead, where a human runs the promote/merge steps.
+SOURCE_WORKFLOWS = {
+    "global-dining": "Refresh Global Dining Data",
+    "japan-dining": "Refresh Data",
+    "plat-stay": "Refresh Data",
+    "love-dining": "Refresh Love Dining",
+    "table-for-two-roster": "Refresh Table for Two",
+    "table-for-two-menus": "Refresh Table for Two",
+    "table-for-two-availability": "Table for Two Alerts",
+    "google-maps-ratings": "Refresh Google Maps Ratings",
+}
+UNOWNED_SOURCES = {"tabelog-ratings"}
+
+
+class Action(str, Enum):
+    DISPATCH = "dispatch"
+    ESCALATE = "escalate"
+    SKIP = "skip"
+
+
+@dataclass(frozen=True)
+class Plan:
+    workflow: str
+    action: Action
+    source_ids: tuple[str, ...]
+    reason: str
+
+
+def parse_utc(value: str | None) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def is_degraded(source: dict) -> bool:
+    """A source needs attention when it is past its own freshness limit or failing.
+
+    `review_required` is a human review flag, not staleness, so it is not included.
+    """
+    return (
+        source.get("freshness_state") in DEGRADED_FRESHNESS
+        or source.get("failure_state") not in (None, "clear")
+    )
+
+
+def degraded_sources(health: dict) -> list[dict]:
+    return [source for source in health.get("sources") or [] if is_degraded(source)]
+
+
+def plan_actions(
+    sources: list[dict],
+    last_dispatch_at: dict[str, datetime | None],
+    now: datetime,
+    retry_window_hours: float = RETRY_WINDOW_HOURS,
+) -> list[Plan]:
+    """One plan per owning workflow: retry once per window, then escalate."""
+    by_workflow: dict[str, list[str]] = {}
+    for source in sources:
+        workflow = SOURCE_WORKFLOWS.get(str(source.get("id")))
+        if not workflow:
+            continue
+        by_workflow.setdefault(workflow, []).append(str(source["id"]))
+
+    cutoff = now - timedelta(hours=retry_window_hours)
+    plans = []
+    for workflow, source_ids in sorted(by_workflow.items()):
+        previous = last_dispatch_at.get(workflow)
+        if previous is None or previous < cutoff:
+            action, reason = Action.DISPATCH, "no manual or watchdog retry in the window"
+        else:
+            action, reason = Action.ESCALATE, f"a retry at {previous:%Y-%m-%dT%H:%M:%SZ} did not clear it"
+        plans.append(Plan(workflow, action, tuple(sorted(source_ids)), reason))
+    return plans
+
+
+def issue_body(sources: list[dict], plans: list[Plan], now: datetime) -> str:
+    lines = [
+        f"Source health reported degraded sources at {now:%Y-%m-%dT%H:%M:%SZ}.",
+        "",
+        "| Source | Freshness | Failure | Last checked | Limit |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for source in sorted(sources, key=lambda item: str(item.get("id"))):
+        lines.append(
+            f"| {source.get('id')} | {source.get('freshness_state')} | "
+            f"{source.get('failure_state')} | {source.get('checked_at')} | "
+            f"{source.get('stale_after_hours')}h |"
+        )
+    lines += ["", "Watchdog decisions:", ""]
+    for plan in plans:
+        lines.append(f"- `{plan.workflow}` -> {plan.action.value} ({plan.reason})")
+    for source_id in sorted(str(s.get("id")) for s in sources if s.get("id") in UNOWNED_SOURCES):
+        lines.append(f"- `{source_id}` -> no workflow refreshes this; it needs a manual run")
+    lines += [
+        "",
+        "Only one of these is open at a time. Close it once the sources report",
+        "`current` again; the watchdog opens a fresh one if they degrade later.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, check=False)
+
+
+def last_workflow_dispatch(workflow: str) -> datetime | None:
+    result = run(
+        [
+            "gh", "run", "list",
+            "--workflow", workflow,
+            "--event", "workflow_dispatch",
+            "--limit", "10",
+            "--json", "createdAt",
+        ]
+    )
+    if result.returncode != 0:
+        # Treat an unreadable history as "already retried" so a broken gh call
+        # escalates instead of dispatching on every 30-minute monitor run.
+        print(f"watchdog: cannot read runs for {workflow}: {result.stderr.strip()}", file=sys.stderr)
+        return datetime.now(timezone.utc)
+    stamps = [parse_utc(entry.get("createdAt")) for entry in json.loads(result.stdout or "[]")]
+    valid = [stamp for stamp in stamps if stamp]
+    return max(valid) if valid else None
+
+
+def dispatch(workflow: str) -> bool:
+    result = run(["gh", "workflow", "run", workflow])
+    if result.returncode != 0:
+        print(f"watchdog: dispatch failed for {workflow}: {result.stderr.strip()}", file=sys.stderr)
+        return False
+    return True
+
+
+def escalate(body: str) -> None:
+    """Open one issue and leave it. The monitor runs every 30 minutes, so
+    commenting on each pass would bury the signal it is meant to raise."""
+    run(["gh", "label", "create", ISSUE_LABEL, "--color", "B60205",
+         "--description", "A refresh source is stale or failing"])
+    found = run(["gh", "issue", "list", "--state", "open", "--label", ISSUE_LABEL,
+                 "--search", f"{ISSUE_TITLE} in:title", "--json", "number", "--jq", ".[0].number // empty"])
+    if (found.stdout or "").strip():
+        print("watchdog: an open source-health issue already carries this", file=sys.stderr)
+        return
+    body_path = Path("/tmp/watchdog-stale-sources.md")
+    body_path.write_text(body, encoding="utf-8")
+    run(["gh", "issue", "create", "--title", ISSUE_TITLE,
+         "--label", ISSUE_LABEL, "--body-file", str(body_path)])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--health", type=Path, default=DEFAULT_HEALTH_PATH)
+    parser.add_argument("--retry-window-hours", type=float, default=RETRY_WINDOW_HOURS)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    health = json.loads(args.health.read_text(encoding="utf-8"))
+    sources = degraded_sources(health)
+    if not sources:
+        print("watchdog: every source is within its freshness limit")
+        return 0
+
+    now = datetime.now(timezone.utc)
+    workflows = {SOURCE_WORKFLOWS[s["id"]] for s in sources if s.get("id") in SOURCE_WORKFLOWS}
+    last_dispatch = (
+        {workflow: None for workflow in workflows}
+        if args.dry_run
+        else {workflow: last_workflow_dispatch(workflow) for workflow in workflows}
+    )
+    plans = plan_actions(sources, last_dispatch, now, args.retry_window_hours)
+
+    unowned = [s["id"] for s in sources if s.get("id") not in SOURCE_WORKFLOWS]
+    for source_id in unowned:
+        print(f"watchdog: {source_id} is degraded and no workflow can refresh it", file=sys.stderr)
+
+    escalating = [plan for plan in plans if plan.action is Action.ESCALATE]
+    for plan in plans:
+        print(f"watchdog: {plan.workflow} -> {plan.action.value} ({plan.reason}) for {', '.join(plan.source_ids)}")
+        if args.dry_run or plan.action is not Action.DISPATCH:
+            continue
+        if not dispatch(plan.workflow):
+            escalating.append(plan)
+
+    if (escalating or unowned) and not args.dry_run:
+        escalate(issue_body(sources, plans, now))
+    # Staying quiet keeps the monitor green; the issue carries the signal.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The gap this closes

Staleness detection already worked. `source_health.py` computes per-source limits, `Monitor Source Health` runs every 30 minutes, and `updates.json` holds 31 `source_stale` and 36 `source_recovered` transitions. Nothing acted on any of them.

The only outbound channel is `dispatch_owner_updates.py`, and the service reports `owner_alerts_enabled: false` because `OWNER_ALERT_INGEST_URL` and `OWNER_ALERT_INGEST_TOKEN` were never set. So a detected outage reached nobody except a raw Actions failure email.

Concretely: `Refresh Data` failed on 2026-09-02 and nothing retried it. Japan dining and Plat Stay sat 39 hours stale, against a 36 hour limit, until a manual re-run today.

## What the watchdog does

`scripts/watchdog_stale_sources.py`, run at the end of every `Monitor Source Health` pass:

1. Picks sources past their own `stale_after_hours`, or with a non-clear `failure_state`. `review_required` is a human review flag and is deliberately excluded.
2. Re-dispatches the owning workflow, at most once per workflow per 6 hours. Sources that share a workflow collapse into a single dispatch, so a `Refresh Data` outage triggers one run, not two.
3. If a retry already ran inside that window and the source is still degraded, it opens one `source-health` issue. Only one stays open at a time, so a 30 minute cadence cannot spam it.

`tabelog-ratings` is intentionally unmapped. `Match Tabelog Candidates` uploads a candidate artifact and commits nothing to `data/`, so no retry could ever clear its staleness. It escalates to the issue, where the promote and merge steps are run by hand. It also gains a monthly cron, with literal input defaults because a scheduled run carries no inputs.

## Verification

- 15 new tests: the review-flag exclusion, first-sighting dispatch, shared-workflow collapsing, the retry window in both directions, the unowned-source path, and that every mapped workflow exists and accepts `workflow_dispatch`.
- Dry run against a simulated outage collapses japan-dining plus plat-stay into one `Refresh Data` dispatch and gives TFT availability its own.
- Dry run against current real health correctly reports only `tabelog-ratings`.
- Full suite: 557 Python tests, 19 node tests.

## Note

`actions: write` and `issues: write` are added to the monitor workflow. `workflow_dispatch` is one of the documented exceptions where `GITHUB_TOKEN` does create a new run, so no PAT is needed.

https://claude.ai/code/session_01R8A3zoZuYT1xZsch9oVKgn