### PR TITLE
fix: stop one listing miss from unpublishing a reviewed TFT menu

### DIFF
--- a/data/table-for-two.json
+++ b/data/table-for-two.json
@@ -119484,20 +119484,39 @@
         "opening_hour": "Monday\t7:30 am–5:30 pm\nTuesday\t7:30 am–5:30 pm\nWednesday 7:30 am–5:30 pm\nThursday 7:30 am–5:30 pm\nFriday 7:30 am–5:30 pm\nSaturday 7:30 am–5:30 pm\nSunday 7:30 am–5:30 pm",
         "website_detail_url": "https://www.diningcity.sg/singapore/Sarnies"
       },
-      "menu_pdfs": {},
+      "menu_pdfs": {
+        "platinum": {
+          "status": "published",
+          "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Sarnies-Menu.pdf",
+          "filename": "Sarnies-Menu.pdf",
+          "card": "platinum",
+          "label": "Platinum",
+          "checked_at": "2026-09-08T23:49:22Z",
+          "first_seen_at": "2026-09-02T22:00:42Z",
+          "last_seen_at": "2026-09-08T23:49:22Z",
+          "sha256": "3c1a4122d5d589755dce2fb4aaa677385edf65ccc0cc412681023a811ce03f95",
+          "bytes": 3298511,
+          "aem_created": "Tue Jun 30 2026 02:40:36 GMT-0700",
+          "changed_at": null,
+          "review_manifest_sha256": "0017058c0dfb0baf2f7293628e87e6ddc0e4b52e101d33371ed0cfe868ff2607",
+          "reviewed_at": "2026-09-02T22:01:32Z"
+        }
+      },
       "menu_pdf": {
-        "status": "no_pdf_found",
-        "url": null,
-        "filename": null,
-        "card": null,
-        "label": null,
-        "checked_at": "2026-09-09T23:48:32Z",
+        "status": "published",
+        "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Sarnies-Menu.pdf",
+        "filename": "Sarnies-Menu.pdf",
+        "card": "platinum",
+        "label": "Platinum",
+        "checked_at": "2026-09-08T23:49:22Z",
         "first_seen_at": "2026-09-02T22:00:42Z",
         "last_seen_at": "2026-09-08T23:49:22Z",
-        "sha256": null,
-        "bytes": null,
-        "aem_created": null,
-        "changed_at": null
+        "sha256": "3c1a4122d5d589755dce2fb4aaa677385edf65ccc0cc412681023a811ce03f95",
+        "bytes": 3298511,
+        "aem_created": "Tue Jun 30 2026 02:40:36 GMT-0700",
+        "changed_at": null,
+        "review_manifest_sha256": "0017058c0dfb0baf2f7293628e87e6ddc0e4b52e101d33371ed0cfe868ff2607",
+        "reviewed_at": "2026-09-02T22:01:32Z"
       }
     },
     {

--- a/scripts/fetch_tft_menus.py
+++ b/scripts/fetch_tft_menus.py
@@ -368,6 +368,17 @@ def venue_menu_info(
     previous = previous or {}
 
     if listing_entry is None:
+        # A menu can drop out of one listing fetch and still be live at its
+        # recorded URL, so a single miss is not evidence of removal. Wiping on
+        # it destroys the published state an approved review receipt points at,
+        # which wedges the pipeline: verify_decision_receipts then raises, and
+        # this fetcher calls that verifier on startup, so it can never
+        # re-discover the menu and heal itself. Keep what review approved and
+        # let last_seen_at carry the staleness.
+        if previous.get("status") == "published" and re.fullmatch(
+            r"[0-9a-f]{64}", str(previous.get("sha256"))
+        ):
+            return dict(previous)
         status = "buffet_no_menu_expected" if has_buffet_tag(venue) else "no_pdf_found"
         return {
             "status": status,

--- a/scripts/fetch_tft_menus.py
+++ b/scripts/fetch_tft_menus.py
@@ -368,16 +368,11 @@ def venue_menu_info(
     previous = previous or {}
 
     if listing_entry is None:
-        # A menu can drop out of one listing fetch and still be live at its
-        # recorded URL, so a single miss is not evidence of removal. Wiping on
-        # it destroys the published state an approved review receipt points at,
-        # which wedges the pipeline: verify_decision_receipts then raises, and
-        # this fetcher calls that verifier on startup, so it can never
-        # re-discover the menu and heal itself. Keep what review approved and
-        # let last_seen_at carry the staleness.
-        if previous.get("status") == "published" and re.fullmatch(
-            r"[0-9a-f]{64}", str(previous.get("sha256"))
-        ):
+        # One miss is not proof of removal, and wiping wedges the pipeline:
+        # the approved receipt still points at the published menu, so
+        # verify_decision_receipts raises, and this fetcher runs that verifier
+        # on startup, so it can never re-discover the menu and heal itself.
+        if previous.get("status") == "published":
             return dict(previous)
         status = "buffet_no_menu_expected" if has_buffet_tag(venue) else "no_pdf_found"
         return {

--- a/scripts/tests/test_tft_menu_pdf_retention.py
+++ b/scripts/tests/test_tft_menu_pdf_retention.py
@@ -138,3 +138,70 @@ def test_default_approval_fails_when_retained_candidate_is_unusable(
 
     with pytest.raises(ValueError, match="observation archive|content-addressed path"):
         apply_tft_menu_review.main()
+
+
+PUBLISHED_MENU = {
+    "status": "published",
+    "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Sarnies-Menu.pdf",
+    "filename": "Sarnies-Menu.pdf",
+    "card": "platinum",
+    "label": "Platinum",
+    "checked_at": "2026-09-08T23:49:22Z",
+    "first_seen_at": "2026-09-02T22:00:42Z",
+    "last_seen_at": "2026-09-08T23:49:22Z",
+    "sha256": "3c1a4122d5d589755dce2fb4aaa677385edf65ccc0cc412681023a811ce03f95",
+    "bytes": 3298511,
+    "aem_created": "Tue Jun 30 2026 02:40:36 GMT-0700",
+    "changed_at": None,
+    "review_manifest_sha256": "0017058c0dfb0baf2f7293628e87e6ddc0e4b52e101d33371ed0cfe868ff2607",
+    "reviewed_at": "2026-09-02T22:01:32Z",
+}
+
+
+def test_one_listing_miss_does_not_unpublish_a_reviewed_menu():
+    """A menu absent from a single listing fetch must survive that fetch.
+
+    A transient discovery miss wiped Sarnies' approved menu on 2026-09-09 while
+    the PDF was still live at its recorded URL. That wedged the whole pipeline:
+    the approved receipt still claimed the menu was published, so
+    verify_decision_receipts raised, and because fetch_tft_menus calls that
+    verifier on startup the fetcher could no longer re-discover and republish.
+    """
+    info = fetch_tft_menus.venue_menu_info(
+        {"id": "tft-sarnies", "name": "Sarnies", "category": "cafe"},
+        None,
+        None,
+        "2026-09-09T23:48:32Z",
+        dict(PUBLISHED_MENU),
+    )
+
+    assert info["status"] == "published"
+    assert info["sha256"] == PUBLISHED_MENU["sha256"]
+    assert info["review_manifest_sha256"] == PUBLISHED_MENU["review_manifest_sha256"]
+
+
+def test_a_listing_miss_still_unpublishes_a_menu_that_was_never_published():
+    """Retention is only for state worth keeping, so a non-published menu still clears."""
+    info = fetch_tft_menus.venue_menu_info(
+        {"id": "tft-example", "name": "Example", "category": "cafe"},
+        None,
+        None,
+        "2026-09-09T23:48:32Z",
+        {"status": "no_pdf_found", "sha256": None, "filename": None},
+    )
+
+    assert info["status"] == "no_pdf_found"
+    assert info["sha256"] is None
+
+
+def test_a_buffet_listing_miss_keeps_reporting_buffet():
+    """The buffet branch must not be swallowed by the retention guard."""
+    info = fetch_tft_menus.venue_menu_info(
+        {"id": "tft-buffet", "name": "Buffet Place", "category": "buffet"},
+        None,
+        None,
+        "2026-09-09T23:48:32Z",
+        {},
+    )
+
+    assert info["status"] == "buffet_no_menu_expected"

--- a/scripts/tests/test_tft_menu_pdf_retention.py
+++ b/scripts/tests/test_tft_menu_pdf_retention.py
@@ -142,66 +142,27 @@ def test_default_approval_fails_when_retained_candidate_is_unusable(
 
 PUBLISHED_MENU = {
     "status": "published",
-    "url": "https://www.americanexpress.com/content/dam/amex/en-sg/benefits/the-platinum-card/dining/Sarnies-Menu.pdf",
+    "url": "https://www.americanexpress.com/.../Sarnies-Menu.pdf",
     "filename": "Sarnies-Menu.pdf",
-    "card": "platinum",
-    "label": "Platinum",
-    "checked_at": "2026-09-08T23:49:22Z",
-    "first_seen_at": "2026-09-02T22:00:42Z",
-    "last_seen_at": "2026-09-08T23:49:22Z",
     "sha256": "3c1a4122d5d589755dce2fb4aaa677385edf65ccc0cc412681023a811ce03f95",
-    "bytes": 3298511,
-    "aem_created": "Tue Jun 30 2026 02:40:36 GMT-0700",
-    "changed_at": None,
     "review_manifest_sha256": "0017058c0dfb0baf2f7293628e87e6ddc0e4b52e101d33371ed0cfe868ff2607",
-    "reviewed_at": "2026-09-02T22:01:32Z",
 }
 
 
+def _info(venue, previous):
+    return fetch_tft_menus.venue_menu_info(venue, None, None, "2026-09-09T23:48:32Z", previous)
+
+
 def test_one_listing_miss_does_not_unpublish_a_reviewed_menu():
-    """A menu absent from a single listing fetch must survive that fetch.
-
-    A transient discovery miss wiped Sarnies' approved menu on 2026-09-09 while
-    the PDF was still live at its recorded URL. That wedged the whole pipeline:
-    the approved receipt still claimed the menu was published, so
-    verify_decision_receipts raised, and because fetch_tft_menus calls that
-    verifier on startup the fetcher could no longer re-discover and republish.
-    """
-    info = fetch_tft_menus.venue_menu_info(
-        {"id": "tft-sarnies", "name": "Sarnies", "category": "cafe"},
-        None,
-        None,
-        "2026-09-09T23:48:32Z",
-        dict(PUBLISHED_MENU),
-    )
-
-    assert info["status"] == "published"
-    assert info["sha256"] == PUBLISHED_MENU["sha256"]
-    assert info["review_manifest_sha256"] == PUBLISHED_MENU["review_manifest_sha256"]
+    """A miss wiped Sarnies on 2026-09-09 while the PDF was still live, wedging the pipeline."""
+    assert _info({"name": "Sarnies", "category": "cafe"}, dict(PUBLISHED_MENU)) == PUBLISHED_MENU
 
 
 def test_a_listing_miss_still_unpublishes_a_menu_that_was_never_published():
-    """Retention is only for state worth keeping, so a non-published menu still clears."""
-    info = fetch_tft_menus.venue_menu_info(
-        {"id": "tft-example", "name": "Example", "category": "cafe"},
-        None,
-        None,
-        "2026-09-09T23:48:32Z",
-        {"status": "no_pdf_found", "sha256": None, "filename": None},
-    )
-
-    assert info["status"] == "no_pdf_found"
-    assert info["sha256"] is None
+    """Retention only covers state worth keeping."""
+    assert _info({"name": "Example", "category": "cafe"}, {"status": "no_pdf_found"})["status"] == "no_pdf_found"
 
 
 def test_a_buffet_listing_miss_keeps_reporting_buffet():
-    """The buffet branch must not be swallowed by the retention guard."""
-    info = fetch_tft_menus.venue_menu_info(
-        {"id": "tft-buffet", "name": "Buffet Place", "category": "buffet"},
-        None,
-        None,
-        "2026-09-09T23:48:32Z",
-        {},
-    )
-
-    assert info["status"] == "buffet_no_menu_expected"
+    """The buffet branch must not be swallowed by the guard."""
+    assert _info({"name": "Buffet Place", "category": "buffet"}, {})["status"] == "buffet_no_menu_expected"


### PR DESCRIPTION
## What was failing

Every `Table for Two Alerts` and `Refresh Table for Two` run since 2026-09-09 failed with:

```
ValueError: latest approved TFT menu decision does not match active menu
```

Three failed runs trace to this: `34443202409`, `34424172762`, `34418375525`. (A fourth recent failure, `34266322753`, is unrelated: the Railway live-freshness check firing its designed fail-closed alarm.)

## Root cause

`venue_menu_info` wiped a published menu whenever the venue matched nothing in a listing fetch, treating a single transient miss as proof that Amex had removed the PDF. There was already a guard for the sibling case (listing entry present, download failed), but none for the miss itself.

Sarnies hit it on 2026-09-09 in commit `d2bce1a`. Nothing upstream had actually changed:

| Evidence | Value |
|---|---|
| Live URL | HTTP 200, `content-length: 3298511` |
| Live sha256 | `3c1a4122…03f95` |
| Approved receipt `asset_sha256` | `3c1a4122…03f95` |
| Retained bytes in `data/reviews/tft-menu-pdfs` | `3c1a4122…03f95` |

## Why it could not self-heal

The wipe left an approved receipt claiming a menu that was no longer published, so `verify_decision_receipts` raised. `fetch_tft_menus` calls that verifier on startup, so the fetcher aborted before it could re-discover the menu and republish it. `build_tft_guide_catalog` raised for the same reason. The published Telegram catalogue stayed frozen at its 2026-09-08 state.

## The fix

Retain a published menu across a listing miss, mirroring the guard that already exists for a failed download, and restore the Sarnies state the wipe destroyed. `last_seen_at` still carries the staleness, so a genuine delisting stays visible.

## Verification

- `python3 scripts/build_tft_guide_catalog.py` → exit 0 (was raising)
- `python3 scripts/fetch_tft_menus.py --dry-run` → `OK  Sarnies  Platinum: Sarnies-Menu.pdf (3,298,511B)` (was aborting on startup)
- 315 Python tests + 30 subtests pass, 20 JS tests pass
- New regression test fails on the old code and passes on the new

https://claude.ai/code/session_01CAHGr5PpRAiEjdExA8pkcN
