### PR TITLE
fix: stop a retained menu from counting as a listing match

### DIFF
--- a/scripts/fetch_tft_menus.py
+++ b/scripts/fetch_tft_menus.py
@@ -566,6 +566,7 @@ def main() -> int:
         concrete_candidate_queued = False
         previous_menus = venue.get("menu_pdfs") or {}
         source_infos = {}
+        listed_sources: set[str] = set()
         listing_matches = {}
         for source_key, listing in listings.items():
             candidates = match_venue_candidates(venue["name"], list(listing.keys()))
@@ -635,6 +636,7 @@ def main() -> int:
             info = venue_menu_info(venue, entry, pdf_bytes, checked_at, previous)
             if entry:
                 observed_assets.add((source_key, entry["filename"]))
+                listed_sources.add(source_key)
             active_info = active_menu_after_observation(info, previous)
             if active_info is not None:
                 source_infos[source_key] = active_info
@@ -689,14 +691,21 @@ def main() -> int:
         published_infos = {
             key: info for key, info in source_infos.items() if info["status"] == "published"
         }
+        # A menu retained across a listing miss is still published, but it was not
+        # matched this run. Counting it would hide the miss from source health,
+        # which derives menu coverage from these numbers.
+        listed_published = {
+            key: info for key, info in published_infos.items() if key in listed_sources
+        }
         if published_infos:
-            matched_menu_count += len(published_infos)
-            matched_venue_count += 1
+            matched_menu_count += len(listed_published)
+            matched_venue_count += 1 if listed_published else 0
             parts = []
             for key, info in published_infos.items():
                 size_str = f"{info['bytes']:,}B" if info["bytes"] else "?"
-                parts.append(f"{AEM_MENU_SOURCES[key]['label']}: {info['filename']} ({size_str})")
-            print(f"  OK  {venue['name']:38s}  {' | '.join(parts)}")
+                seen = "" if key in listed_sources else " [retained, not listed]"
+                parts.append(f"{AEM_MENU_SOURCES[key]['label']}: {info['filename']} ({size_str}){seen}")
+            print(f"  {'OK ' if listed_published else 'RET'}  {venue['name']:38s}  {' | '.join(parts)}")
         elif venue["menu_pdf"]["status"] == "buffet_no_menu_expected":
             buffet_count += 1
             print(f"  BUF {venue['name']:38s}  (buffet — no menu PDF expected)")

--- a/scripts/tests/test_tft_menu_pdf_retention.py
+++ b/scripts/tests/test_tft_menu_pdf_retention.py
@@ -166,3 +166,37 @@ def test_a_listing_miss_still_unpublishes_a_menu_that_was_never_published():
 def test_a_buffet_listing_miss_keeps_reporting_buffet():
     """The buffet branch must not be swallowed by the guard."""
     assert _info({"name": "Buffet Place", "category": "buffet"}, {})["status"] == "buffet_no_menu_expected"
+
+
+def test_a_retained_menu_is_not_counted_as_matched(tmp_path, monkeypatch):
+    """Retention must not make a listing miss look like a match.
+
+    Keeping a published menu across a miss is right, but counting it in
+    venues_matched hides the miss from source health, which derives menu
+    coverage from that number. A matcher regression would then look normal.
+    """
+    data = tmp_path / "tft.json"
+    data.write_text(json.dumps({
+        "venues": [{
+            "id": "tft-x", "name": "Example", "category": "cafe",
+            "menu_pdfs": {"platinum": {
+                "status": "published", "url": "https://www.americanexpress.com/x.pdf",
+                "filename": "x.pdf", "card": "platinum", "label": "Platinum",
+                "sha256": "a" * 64, "bytes": 10, "checked_at": "2026-09-01T00:00:00Z",
+                "first_seen_at": "2026-09-01T00:00:00Z", "last_seen_at": "2026-09-01T00:00:00Z",
+            }},
+        }],
+        "menu_source": {},
+    }))
+    monkeypatch.setattr(fetch_tft_menus, "fetch_aem_menu_listing", lambda key: {})
+    monkeypatch.setattr(sys, "argv", [
+        "fetch_tft_menus.py", "--input", str(data), "--output", str(data),
+        "--cache-dir", "", "--no-download",
+    ])
+
+    assert fetch_tft_menus.main() == 0
+
+    out = json.loads(data.read_text())
+    assert out["venues"][0]["menu_pdfs"]["platinum"]["status"] == "published"
+    assert out["menu_source"]["venues_matched"] == 0
+    assert out["menu_source"]["menus_matched"] == 0


### PR DESCRIPTION
Follow-up to #71. That PR fixed the wedge but introduced a blind spot, which I found while validating it rather than before merging.

## The blind spot

#71 retains a published menu across a listing miss, which is correct. But `venues_matched` counted any venue holding a published menu, so a retained miss reported identical coverage to a real match. A controlled A/B before this fix:

```
control: full listing            venues_matched=20  review_queue_count=8
Sarnies dropped from listing     venues_matched=20  review_queue_count=8
```

Identical. `table-for-two-menus` source health derives menu coverage from that number, so a matcher regression would have looked completely normal. Before #71 a miss at least surfaced as `no_pdf_found` and landed in the review queue.

## The fix

Count only what the run actually saw in a listing. Same A/B after:

```
control: full listing            venues_matched=20  -> unavailable=10   OK   Sarnies ...
Sarnies dropped from listing     venues_matched=19  -> unavailable=11   RET  Sarnies ... [retained, not listed]
```

The menu stays published in both, so #71's wedge fix is unaffected. The miss is now visible in the number source health already consumes, so no new health field or escalation machinery was needed.

## Verification

- New test drives `fetch_tft_menus.main()` fully offline (stubbed listing, `--no-download`) and fails on the pre-fix code
- 317 Python tests + 30 subtests pass, 20 JS tests pass
- `build_tft_guide_catalog.py` and `build_tft_slot_snapshot.py` still exit 0

https://claude.ai/code/session_01CAHGr5PpRAiEjdExA8pkcN