### PR TITLE
perf: skip a Pages deploy when main is already live

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  deployments: read
   pages: write
   id-token: write
 
@@ -26,8 +27,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  # Every upstream workflow triggers this one on completion, whether or not it
+  # committed anything. Monitor Source Health alone runs ~7x/day and commits
+  # about once a week, so most runs rebuilt and redeployed identical bytes.
+  changed:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ steps.check.outputs.deploy }}
+    steps:
+      - name: Compare main against the live Pages deployment
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          head="$(gh api "repos/$REPO/commits/main" --jq .sha)"
+          # Newest deployment that actually succeeded, so a failed deploy cannot
+          # wedge the site by making later runs think its commit is already live.
+          live=""
+          while read -r sha url; do
+            if [ "$(gh api "$url" --jq '.[0].state // ""')" = "success" ]; then
+              live="$sha"
+              break
+            fi
+          done < <(gh api "repos/$REPO/deployments?environment=github-pages&per_page=10" \
+                     --jq '.[]|"\(.sha) \(.statuses_url)"')
+          if [ "$head" = "$live" ]; then
+            echo "main $head is already live; skipping redeploy." | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    needs: changed
+    if: needs.changed.outputs.deploy == 'true'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## The waste

Deploy Pages chains off six workflows via `workflow_run: types: [completed]`, which fires whether or not the upstream committed anything.

Measured over the last 5 days:

| | |
|---|---|
| Monitor Source Health runs | ~35 |
| Commits it produced | **1** |
| Deploy Pages runs it triggered | ~35 |

So ~34 full site rebuilds redeployed byte-identical content. Each one runs the audits, the test suite, the build, a hardcoded `sleep 60`, and a deploy, at ~1m25s.

Over 7 days Deploy Pages ran 158 times, which is most of what fills the Actions tab.

## The guard

One small job compares `main` against the newest **succeeded** github-pages deployment and skips the deploy when they match.

Keying off a succeeded deployment rather than simply the newest matters: `actions/deploy-pages` creates a deployment record even when it fails, so comparing against the newest would let a failed deploy convince every later run that its commit was already live, leaving the site stale until the next commit.

## Verified

Ran the guard's logic against live API state:

```
head=b4aebca265a732f0e971b4b4aa2a4343673bdc99
live=b4aebca265a732f0e971b4b4aa2a4343673bdc99
RESULT: deploy=false (correctly skips a no-op)
```

`workflow_dispatch` and `push` still deploy whenever main is ahead. Nothing about what gets built changes.

https://claude.ai/code/session_01CAHGr5PpRAiEjdExA8pkcN