### PR TITLE
fix: stop one unrated venue from blocking every deploy

### DIFF
--- a/scripts/build_public_data_projections.py
+++ b/scripts/build_public_data_projections.py
@@ -30,10 +30,10 @@ def tft_ratings_projection(table_for_two: dict, ratings: dict) -> dict:
     if not isinstance(ratings, dict):
         raise ValueError("Google ratings payload must be an object")
 
-    missing = [venue_id for venue_id in venue_ids if venue_id not in ratings]
-    if missing:
-        raise ValueError(f"Missing Google ratings for Table for Two venues: {', '.join(missing)}")
-    return {venue_id: ratings[venue_id] for venue_id in venue_ids}
+    # Ratings are a weekly enrichment, so a roster addition is unrated until the
+    # scraper next runs. Demanding full coverage here made one new venue block
+    # every deploy for days. Coverage regressions stay visible in source health.
+    return {venue_id: ratings[venue_id] for venue_id in venue_ids if venue_id in ratings}
 
 
 def tft_catalog_projection(table_for_two: dict) -> dict:

--- a/scripts/tests/test_public_data_projections.py
+++ b/scripts/tests/test_public_data_projections.py
@@ -23,12 +23,21 @@ class PublicDataProjectionTests(unittest.TestCase):
             {"tft-a": {"rating": 4.1}, "tft-b": {"rating": 4.8}},
         )
 
-    def test_tft_ratings_fails_closed_when_a_venue_is_missing(self):
-        with self.assertRaisesRegex(ValueError, "tft-b"):
-            projections.tft_ratings_projection(
-                {"venues": [{"id": "tft-a"}, {"id": "tft-b"}]},
-                {"tft-a": {"rating": 4.1}},
-            )
+    def test_tft_ratings_omits_a_venue_that_has_no_rating_yet(self):
+        """A newly listed venue must not block the whole site from deploying.
+
+        Ratings are a weekly enrichment, so every roster addition spends up to a
+        week unrated. Demanding full coverage here blocked 22 Deploy Pages runs
+        over two days when Xing Yue Xuan joined. The frontend already renders a
+        missing rating as null, love-dining already ships unrated venues, and
+        source health already reports ratings coverage.
+        """
+        projected = projections.tft_ratings_projection(
+            {"venues": [{"id": "tft-a"}, {"id": "tft-b"}]},
+            {"tft-a": {"rating": 4.1}},
+        )
+
+        self.assertEqual(projected, {"tft-a": {"rating": 4.1}})
 
     def test_release_summary_excludes_raw_observations(self):
         history = {
@@ -83,8 +92,11 @@ class PublicDataProjectionTests(unittest.TestCase):
         catalog = projections.tft_catalog_projection(table_for_two)
         summary = projections.release_history_summary(history)
 
-        self.assertEqual(len(tft_ratings), len(table_for_two["venues"]))
-        self.assertEqual(set(tft_ratings), {venue["id"] for venue in table_for_two["venues"]})
+        # Bounded by the roster, not equal to it: a venue listed since the last
+        # weekly ratings run is legitimately unrated and must not fail the build.
+        roster_ids = {venue["id"] for venue in table_for_two["venues"]}
+        self.assertTrue(set(tft_ratings).issubset(roster_ids))
+        self.assertTrue(tft_ratings)
         self.assertEqual(len(summary["patterns"]), len(history["patterns"]))
         self.assertNotIn("observations", summary)
         self.assertTrue(all("availability" not in venue for venue in catalog["venues"]))


### PR DESCRIPTION
## The outage

The site has not deployed since 2026-09-11T10:03Z. **22 Deploy Pages runs failed** over two days, all with:

```
ValueError: Missing Google ratings for Table for Two venues: tft-xing-yue-xuan
```

Live site right now is serving the 2026-09-10 snapshot with **30 venues**; the repo has **31**.

## Root cause

`tft_ratings_projection` required a Google rating for every roster venue. Ratings come from a **weekly** scraper (`refresh-ratings.yml`, `cron: "0 2 * * 0"`), so every roster addition is unrated for up to a week. Xing Yue Xuan joined on 2026-09-11 and blocked every deploy from that moment.

## Why full coverage was the wrong contract

Nothing else in this repo expects it:

| Evidence | |
|---|---|
| `web/app.js:1811` | `state.googleRatings[record.id] \|\| null` — already renders a missing rating |
| love-dining | ships **2 of 82** venues unrated, deploys fine |
| source health | `google-maps-ratings` at **99.0%**, 29 records unavailable, tracked and accepted |
| ratings file history | monotonic growth (3808 → 3816), no mass-loss precedent to guard against |

So the guard was inconsistent with the repo's own norm, and coverage regressions are already visible in source health rather than needing a deploy block.

## The change

Bound the projection to the roster rather than require equality. The guarantee worth keeping, that no non-roster id leaks into the public payload, is unchanged and still tested.

## Verification

- The exact Deploy Pages gate now passes: `Ran 33 tests ... OK`, all `test_table_for_two_*.js`, and `test_tft_public_payloads.js`
- `audit_coordinates.py` and `audit_content_provenance.py` both exit 0
- Projection output: `roster=31 rated=30 omitted=['tft-xing-yue-xuan'] leaks non-roster ids: False`
- 20 JS tests pass

Four unrelated Love Dining test failures exist on `main` before this change and are untouched here. They look connected to the 48 `Refresh Love Dining` workflow failures, which I am investigating separately.

https://claude.ai/code/session_01CAHGr5PpRAiEjdExA8pkcN