### PR TITLE
fix: stop roster growth from arming a deploy outage

### DIFF
--- a/scripts/tests/test_public_data_projections.py
+++ b/scripts/tests/test_public_data_projections.py
@@ -8,6 +8,10 @@ from scripts import build_public_data_projections as projections
 
 ROOT = Path(__file__).resolve().parents[2]
 
+# Observed ~4.7KB/venue. Generous enough for real growth, tight enough that a
+# projection leaking bulk back in still trips it.
+MAX_CATALOG_BYTES_PER_VENUE = 12_000
+
 
 class PublicDataProjectionTests(unittest.TestCase):
     def test_tft_ratings_contains_only_exact_venue_ids(self):
@@ -100,10 +104,13 @@ class PublicDataProjectionTests(unittest.TestCase):
         self.assertEqual(len(summary["patterns"]), len(history["patterns"]))
         self.assertNotIn("observations", summary)
         self.assertTrue(all("availability" not in venue for venue in catalog["venues"]))
-        self.assertLess(
-            len(json.dumps(catalog, separators=(",", ":")).encode()),
-            250_000,
-        )
+        # Per venue, not total. A fixed ceiling on a growing roster is a timer:
+        # this one sat at 56% and would have blocked every deploy about 23
+        # venues from now, the same way one unrated venue blocked them for two
+        # days on 2026-09-11. Per-venue still catches the regression that
+        # matters, a projection that starts carrying slots or other bulk again.
+        catalog_bytes = len(json.dumps(catalog, separators=(",", ":")).encode())
+        self.assertLess(catalog_bytes / len(catalog["venues"]), MAX_CATALOG_BYTES_PER_VENUE)
 
     def test_cli_writes_both_outputs(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## The pattern, not just the bug

Two days ago one unrated venue blocked every deploy for two days (22 failed runs, site stuck on a stale snapshot). The cause was a deploy gate asserting on live data.

The same gate still held a second, identical trap: `assertLess(len(catalog), 250_000)`. A fixed ceiling over a growing roster is a timer.

```
catalog size: 139,750 bytes   (55.9% of the ceiling)
bytes/venue:    4,658
venues until every deploy breaks: 23
```

## Fix

Bound bytes **per venue** rather than in total. Growth cannot trip it; the regression it exists to catch still does.

```
today:                    4,836 bytes/venue   (ceiling 12,000, 2.5x headroom)
slots leaked back in:    12,983 bytes/venue   -> trips
```

## Verification

- Exact Deploy Pages gate: `OK`, all `test_table_for_two_*.js`, `test_tft_public_payloads.js`
- Full suite: 0 failures; 20 JS tests pass

## The wider finding

**14 test files assert against live `data/` files.** They are deploy-breaking surfaces waiting for the upstream data to move. Only one currently gates deploys, which is the only reason the other 13 have not caused an outage — and 4 of them were silently broken for two weeks (fixed in #75) precisely because no workflow runs that suite.

This PR fixes the armed one. The general fix is a CI job running the full suite off the deploy path, which I have not added here.

https://claude.ai/code/session_01CAHGr5PpRAiEjdExA8pkcN