### PR TITLE
ci: run the test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,50 @@
+name: Tests
+
+# Deliberately not wired into Deploy Pages. A failing test here should tell you
+# the code is wrong, not stop the site publishing fresh data: one unrated venue
+# blocking the deploy gate already cost two days of stale production on
+# 2026-09-11.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: reminders/requirements-dev.txt
+
+      - name: Install test dependencies
+        run: python3 -m pip install --disable-pip-version-check -r reminders/requirements-dev.txt
+
+      - name: Python suite
+        run: python3 -m pytest scripts/tests -q
+
+      - name: Reminders service suite
+        run: python3 -m pytest reminders/tests -q
+
+      - name: JavaScript suite
+        run: |
+          status=0
+          for test_file in scripts/tests/*.js; do
+            node "$test_file" || { echo "::error::$test_file failed"; status=1; }
+          done
+          exit "$status"


### PR DESCRIPTION
## The gap

CI executed roughly **33 of 625 tests**, all inside a single Deploy Pages step:

```
python3 -m unittest scripts.tests.test_table_for_two_retry \
                    scripts.tests.test_table_for_two_data \
                    scripts.tests.test_public_data_projections
+ scripts/tests/test_table_for_two_*.js
```

Nothing ran `scripts/tests` as a whole, and nothing ran `reminders/tests` at all. That is why four Love Dining tests sat broken for two weeks (fixed in #75) with every workflow green.

## What this adds

| Suite | Tests |
|---|---|
| `scripts/tests` | 316 + 31 subtests |
| `reminders/tests` | 289 |
| JavaScript | 20 |

All currently pass, so this lands green.

## Why it does not gate deploys

Deliberately separate from Deploy Pages. Coupling tests to deployment is what caused the outage this session: one unrated venue made a data assertion raise, 22 deploys failed, and production served a stale snapshot for two days. A failing test should tell you the code is wrong; it should not stop fresh data reaching users.

https://claude.ai/code/session_01CAHGr5PpRAiEjdExA8pkcN