### PR TITLE
chore: stop copying one timestamp onto every venue

### DIFF
--- a/data/table-for-two.json
+++ b/data/table-for-two.json
@@ -797,7 +797,6 @@
       "map_pin_source": "DiningCity public restaurant search",
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -7161,7 +7160,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -9308,7 +9306,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name variant.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -16167,7 +16164,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -18071,7 +18067,6 @@
       "venue_source_url": "https://www.fullertonhotels.com/fullerton-bay-hotel-singapore/dining/restaurants-and-bars/la-brasserie",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -21050,7 +21045,6 @@
       "venue_source_url": "https://osteriamozza.com.sg/",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "not_listed",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "not_currently_in_project",
       "availability": {
         "status": "not_currently_in_project",
@@ -21142,7 +21136,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -24313,7 +24306,6 @@
       "venue_source_url": "https://www.kayaatthestandard.com/",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -32073,7 +32065,6 @@
       "venue_source_url": "https://www.rappu.sg/",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -35875,7 +35866,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -43937,7 +43927,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -47289,7 +47278,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -54573,7 +54561,6 @@
       "venue_source_url": "https://www.vineyardhortpark.com.sg/contact-us-1",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -61233,7 +61220,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_no_seats",
@@ -61330,7 +61316,6 @@
       "venue_source_url": "https://www.fourseasons.com/singapore/dining/restaurants/one_ninety/",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -62292,7 +62277,6 @@
       "venue_source_url": "https://guide.michelin.com/sg/en/singapore-region/singapore/restaurant/latido",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -66533,7 +66517,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -68071,7 +68054,6 @@
       "venue_source_url": "https://www.hilton.com/en/hotels/sinorhi-hilton-singapore-orchard/dining/estate/",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -75838,7 +75820,6 @@
       "venue_source_url": "https://www.panpacific.com/en/hotels-and-resorts/pr-collection-marina-bay/dining/peppermint.html",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -80026,7 +80007,6 @@
       "venue_source_url": "https://www.panpacific.com/en/hotels-and-resorts/pr-beach-road/eat/ginger.html",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -85022,7 +85002,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "not_listed",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "not_currently_in_project",
       "availability": {
         "status": "not_currently_in_project",
@@ -85109,7 +85088,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -98403,7 +98381,6 @@
       "map_pin_note": "Pin is from DiningCity public restaurant search and matches the venue name.",
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -107498,7 +107475,6 @@
       },
       "booking_channel": "Amex Experiences App",
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -109499,7 +109475,6 @@
         "record_sha256": "b7b85f60ac68b0dde10530fd0c3eb2f437334cc588d206dcb0b9fa825ceb2950"
       },
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -118814,7 +118789,6 @@
         "record_sha256": "47e8231b5306a2c1d291148d81e531c2badee9e921ea780bd562ff2e7ed9c271"
       },
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -127250,7 +127224,6 @@
         "record_sha256": "314e17321476d0633ff685e0a2393a8c7c12c2912d3c862c981a5f41ddc5d0cb"
       },
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -130074,7 +130047,6 @@
         "record_sha256": "551452eaac4873da3145350f3af81e80333f377dc2ddd580165d04a6bc24e798"
       },
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -141517,7 +141489,6 @@
         "record_sha256": "ca925b2de417655bd3d94705c635cd6b1e14d13bd15e886db198c1b75cede12c"
       },
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "app_handoff_required",
       "availability": {
         "status": "unknown",
@@ -141583,7 +141554,6 @@
         "record_sha256": "1e28c2a0313abc1769c145a42746cd9ec5489147c637389a51dddaae84e85f5e"
       },
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",
@@ -150461,7 +150431,6 @@
         "record_sha256": "539714d18adfb81e63f374584d7adb90d37abb372805ce72a073b909083bd898"
       },
       "booking_project_status": "active",
-      "booking_project_checked_at": "2026-09-12T13:00:21Z",
       "slot_source_status": "diningcity_amex_platinum_project",
       "availability": {
         "status": "live_available",

--- a/scripts/scrape_table_for_two.py
+++ b/scripts/scrape_table_for_two.py
@@ -1600,9 +1600,6 @@ def normalized_venues(
             **venue,
             "booking_channel": "Amex Experiences App",
             "booking_project_status": booking_project_status,
-            "booking_project_checked_at": (booking_project_source or {}).get(
-                "checked_at"
-            ),
             "slot_source_status": (
                 "not_currently_in_project"
                 if booking_project_status == "not_listed"
@@ -1847,7 +1844,6 @@ def refresh_availability_payload(existing_payload: dict, *, include_profiles: bo
             **venue,
             **operational_fields,
             "booking_project_status": booking_project_status,
-            "booking_project_checked_at": booking_project_source.get("checked_at"),
             "slot_source_status": (
                 "not_currently_in_project"
                 if booking_project_status == "not_listed"

--- a/scripts/tft_roster_reviews.py
+++ b/scripts/tft_roster_reviews.py
@@ -22,7 +22,6 @@ OFFICIAL_URL = "https://www.americanexpress.com/en-sg/benefits/the-platinum-card
 REVIEW_ROOT = Path(__file__).resolve().parents[1] / "data/reviews/table-for-two-roster"
 RUNTIME_FIELDS = {
     "availability",
-    "booking_project_checked_at",
     "booking_project_status",
     "dining_city_profile",
     "menu_pdf",


### PR DESCRIPTION
Part of reducing the commit churn behind the Actions noise.

## The field

`booking_project_checked_at` was written onto every venue on every availability run:

```
payload booking_project_source.checked_at : 2026-09-12T13:00:21Z
per-venue booking_project_checked_at      : 2026-09-12T13:00:21Z
distinct values across 31 venues          : 1
```

One value, copied 31 times, already present at payload level.

**Readers: none.** Not `web/app.js`, not `reminders/`, not the pipeline. Its only other mention was in `tft_roster_reviews.RUNTIME_FIELDS`, the set of fields review comparison deliberately *ignores*.

## Effect

31 lines of churn removed from each availability commit, roughly eight commits a day, in a file the frontend downloads. Diff is 31 pure deletions, no reformatting.

## Verification

- `scripts/tests` 316 + 31 subtests, `reminders/tests` 289, JS 20 — all pass
- `build_tft_slot_snapshot`, `build_tft_guide_catalog`, `check_roster_parity` all clean
- Deploy Pages gate `OK`

## Note

This touches `scrape_table_for_two.py` near the record-construction block your `fix/rebuild-drops-fields` branch also edits, so expect a small conflict there.

https://claude.ai/code/session_01CAHGr5PpRAiEjdExA8pkcN